### PR TITLE
Make sure Metrics is enabled on startup

### DIFF
--- a/src/main/java/skinsrestorer/bukkit/SkinsRestorer.java
+++ b/src/main/java/skinsrestorer/bukkit/SkinsRestorer.java
@@ -59,10 +59,12 @@ public class SkinsRestorer extends JavaPlugin {
         srLogger = new SRLogger();
 
         Metrics metrics = new Metrics(this);
-        metrics.addCustomChart(new Metrics.SingleLineChart("mineskin_calls", MetricsCounter::collectMineskin_calls));
-        metrics.addCustomChart(new Metrics.SingleLineChart("minetools_calls", MetricsCounter::collectMinetools_calls));
-        metrics.addCustomChart(new Metrics.SingleLineChart("mojang_calls", MetricsCounter::collectMojang_calls));
-        metrics.addCustomChart(new Metrics.SingleLineChart("backup_calls", MetricsCounter::collectBackup_calls));
+        if (metrics.isEnabled()) {
+            metrics.addCustomChart(new Metrics.SingleLineChart("mineskin_calls", MetricsCounter::collectMineskin_calls));
+            metrics.addCustomChart(new Metrics.SingleLineChart("minetools_calls", MetricsCounter::collectMinetools_calls));
+            metrics.addCustomChart(new Metrics.SingleLineChart("mojang_calls", MetricsCounter::collectMojang_calls));
+            metrics.addCustomChart(new Metrics.SingleLineChart("backup_calls", MetricsCounter::collectBackup_calls));
+        }
 
         instance = this;
         factory = new UniversalSkinFactory();

--- a/src/main/java/skinsrestorer/bungee/SkinsRestorer.java
+++ b/src/main/java/skinsrestorer/bungee/SkinsRestorer.java
@@ -58,10 +58,12 @@ public class SkinsRestorer extends Plugin {
     public void onEnable() {
         srLogger = new SRLogger();
         Metrics metrics = new Metrics(this);
-        metrics.addCustomChart(new Metrics.SingleLineChart("mineskin_calls", MetricsCounter::collectMineskin_calls));
-        metrics.addCustomChart(new Metrics.SingleLineChart("minetools_calls", MetricsCounter::collectMinetools_calls));
-        metrics.addCustomChart(new Metrics.SingleLineChart("mojang_calls", MetricsCounter::collectMojang_calls));
-        metrics.addCustomChart(new Metrics.SingleLineChart("backup_calls", MetricsCounter::collectBackup_calls));
+        if (metrics.isEnabled()) {
+            metrics.addCustomChart(new Metrics.SingleLineChart("mineskin_calls", MetricsCounter::collectMineskin_calls));
+            metrics.addCustomChart(new Metrics.SingleLineChart("minetools_calls", MetricsCounter::collectMinetools_calls));
+            metrics.addCustomChart(new Metrics.SingleLineChart("mojang_calls", MetricsCounter::collectMojang_calls));
+            metrics.addCustomChart(new Metrics.SingleLineChart("backup_calls", MetricsCounter::collectBackup_calls));
+        }
 
         console = getProxy().getConsole();
 


### PR DESCRIPTION
This change is only small and is not required, but if a user has disabled bStats data from being sent in the configuration, do not attempt to send the data to the plugin. This will increase the plugin loading at startup.