### PR TITLE
Reduce redundancy (Bukkit PlayerJoin)

### DIFF
--- a/src/main/java/skinsrestorer/bukkit/listener/PlayerJoin.java
+++ b/src/main/java/skinsrestorer/bukkit/listener/PlayerJoin.java
@@ -1,43 +1,49 @@
 package skinsrestorer.bukkit.listener;
 
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import skinsrestorer.bukkit.SkinsRestorer;
 import skinsrestorer.shared.exception.SkinRequestException;
 import skinsrestorer.shared.storage.Config;
+import skinsrestorer.shared.storage.SkinStorage;
 import skinsrestorer.shared.utils.C;
 
 /**
  * Created by McLive on 21.01.2019.
  */
 public class PlayerJoin implements Listener {
-    private SkinsRestorer plugin;
+    private final SkinsRestorer plugin;
 
-    public PlayerJoin(SkinsRestorer plugin) {
+    public PlayerJoin(final SkinsRestorer plugin) {
         this.plugin = plugin;
     }
 
     @EventHandler
-    public void onJoin(PlayerJoinEvent e) {
-        Bukkit.getScheduler().runTaskAsynchronously(SkinsRestorer.getInstance(), () -> {
+    public void onJoin(final PlayerJoinEvent e) {
+        if (Config.DISABLE_ONJOIN_SKINS) {
+            // factory.applySkin(e.getPlayer(), SkinStorage.getSkinData(SkinStorage.getPlayerSkin(e.getPlayer().getName())));
+            // shouldn't it just skip it if it's true?
+            return;
+        }
+        
+        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
             try {
-                if (Config.DISABLE_ONJOIN_SKINS) {
-                    // factory.applySkin(e.getPlayer(), SkinStorage.getSkinData(SkinStorage.getPlayerSkin(e.getPlayer().getName())));
-                    // shouldn't it just skip it if it's true?
-                    return;
-                }
-
+                final SkinStorage skinStorage = plugin.getSkinStorage();
+                final Player player = e.getPlayer();
+                final String playerName = player.getName();
+                
                 // Don't change skin if player has no custom skin-name set and his username is invalid
-                if (plugin.getSkinStorage().getPlayerSkin(e.getPlayer().getName()) == null && !C.validUsername(e.getPlayer().getName())) {
-                    System.out.println("[SkinsRestorer] Not applying skin to " + e.getPlayer().getName() + " (invalid username).");
+                if (skinStorage.getPlayerSkin(playerName) == null && !C.validUsername(playerName)) {
+                    System.out.println("[SkinsRestorer] Not applying skin to " + playerName + " (invalid username).");
                     return;
                 }
 
-                String skin = plugin.getSkinStorage().getDefaultSkinNameIfEnabled(e.getPlayer().getName());
+                final String skin = skinStorage.getDefaultSkinNameIfEnabled(playerName);
 
-                SkinsRestorer.getInstance().getFactory().applySkin(e.getPlayer(), plugin.getSkinStorage().getOrCreateSkinForPlayer(skin));
+                plugin.getFactory().applySkin(player, skinStorage.getOrCreateSkinForPlayer(skin));
             } catch (SkinRequestException ignored) {
             }
         });


### PR DESCRIPTION
Remove usage of static methods, don't get multiple times references to objects, don't create task if unnecesary, make final when possible.