### PR TITLE
Allowing single Non-Word-Character in front of the Username

### DIFF
--- a/src/main/java-templates/skinsrestorer/velocity/listener/GameProfileRequest.java
+++ b/src/main/java-templates/skinsrestorer/velocity/listener/GameProfileRequest.java
@@ -31,7 +31,7 @@ public class GameProfileRequest {
         }
 
         // Don't change skin if player has no custom skin-name set and his username is invalid
-        if (plugin.getSkinStorage().getPlayerSkin(nick) == null && !C.validUsername(nick.replaceAll("\\W", ""))) {
+        if (plugin.getSkinStorage().getPlayerSkin(nick) == null && !C.validUsername(nick)) {
             System.out.println("[SkinsRestorer] Not applying skin to " + nick + " (invalid username).");
             return;
         }

--- a/src/main/java/skinsrestorer/bungee/listeners/LoginListener.java
+++ b/src/main/java/skinsrestorer/bungee/listeners/LoginListener.java
@@ -39,7 +39,7 @@ public class LoginListener implements Listener {
             final String nick = connection.getName();
 
             // Don't change skin if player has no custom skin-name set and his username is invalid
-            if (plugin.getSkinStorage().getPlayerSkin(nick) == null && !C.validUsername(nick.replaceAll("\\W", ""))) {
+            if (plugin.getSkinStorage().getPlayerSkin(nick) == null && !C.validUsername(nick)) {
                 System.out.println("[SkinsRestorer] Not applying skin to " + connection.getName() + " (invalid username).");
                 return;
             }

--- a/src/main/java/skinsrestorer/shared/utils/C.java
+++ b/src/main/java/skinsrestorer/shared/utils/C.java
@@ -4,7 +4,8 @@ import java.util.regex.Pattern;
 
 public class C {
 
-    private static Pattern namePattern = Pattern.compile("^[a-zA-Z0-9_\\-]+$");
+//    private static Pattern namePattern = Pattern.compile("^[a-zA-Z0-9_\\-]+$");
+    private static Pattern namePattern = Pattern.compile("^\\W?[a-zA-Z0-9_]{3,16}$");
     private static Pattern urlPattern = Pattern.compile("^https?://.*");
 
     public static String c(String msg) {
@@ -12,8 +13,8 @@ public class C {
     }
 
     public static boolean validUsername(String username) {
-        if (username.length() > 16)
-            return false;
+        //if (username.length() > 16)
+        //    return false; //won't be needed as the regex allows only 16 characters + one Non-WOrd character in front
 
         return namePattern.matcher(username).matches();
     }


### PR DESCRIPTION
How about this for issue #323 : instead of removing all non-word characters and checking for word characters only afterwards, you can allow a single non word character in front and leave the rest normal. Otherwise you make your name check unnecessary as the won't be any characters left then checked for