### PR TITLE
dismount a player before applying skin (fixes #289)

### DIFF
--- a/src/main/java/skinsrestorer/bukkit/skinfactory/UniversalSkinFactory.java
+++ b/src/main/java/skinsrestorer/bukkit/skinfactory/UniversalSkinFactory.java
@@ -20,6 +20,14 @@ public class UniversalSkinFactory extends SkinFactory {
             return;
 
         Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> {
+
+        	//dismounts a player before refreshing, which prevents desync 
+        	if (player.getVehicle() != null) {
+        		
+        		player.getVehicle().removePassenger(player);
+
+        	}
+        	
             for (Player ps : Bukkit.getOnlinePlayers()) {
                 // Some older spigot versions only support hidePlayer(player)
                 try {

--- a/src/main/java/skinsrestorer/bukkit/skinfactory/UniversalSkinFactory.java
+++ b/src/main/java/skinsrestorer/bukkit/skinfactory/UniversalSkinFactory.java
@@ -1,12 +1,11 @@
 package skinsrestorer.bukkit.skinfactory;
 
 import lombok.RequiredArgsConstructor;
-import skinsrestorer.shared.storage.Config;
-
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+import skinsrestorer.shared.storage.Config;
 
 import java.io.File;
 import java.util.function.Consumer;
@@ -16,32 +15,45 @@ public class UniversalSkinFactory extends SkinFactory {
     private final Plugin plugin;
     private final Consumer<Player> refresh = detectRefresh();
     public static final String NMS_VERSION = Bukkit.getServer().getClass().getPackage().getName().substring(23);
+    private Entity Vehicle;
+    boolean checkoptfilechecked;
+    boolean DisableDismoundPlayer;
+    boolean EnableDismountentities;
+
 
     @Override
     public void updateSkin(Player player) {
         if (!player.isOnline())
             return;
 
+        if (checkoptfilechecked)
+            this.checkoptfile();
+
         Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> {
+            //dismounts & remounts a player on refreshing, which prevents desync caused by riding a horse, or plugins that allow sitting
+            Vehicle = player.getVehicle();
+            if ((Config.DISMOUNT_PLAYER_ON_UPDATE || !DisableDismoundPlayer) && Vehicle != null) {
 
-        	//dismounts a player before refreshing, which prevents desync caused by riding a horse, or plugins that allow sitting
-        	if (Config.DISMOUNT_PLAYER_ON_UPDATE && player.getVehicle() != null) {
-        		
-        		player.getVehicle().removePassenger(player);
 
-        	}
-        	
-        	//dismounts all entities riding the player, preventing desync from plugins that allow players to mount each other
-        	if (Config.DISMOUNT_PASSENGERS_ON_UPDATE && !player.getPassengers().isEmpty()) {
-        		
-        		for (Entity passenger : player.getPassengers()) {
-        		
-        			player.removePassenger(passenger);
-        			
-        		}
+                Vehicle.removePassenger(player);
+                Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
+                    public void run() {
+                        Vehicle.addPassenger(player);
+                    }
+                }, 1);
 
-        	}
-        	
+            }
+
+            //dismounts all entities riding the player, preventing desync from plugins that allow players to mount each other
+            if ((Config.DISMOUNT_PASSENGERS_ON_UPDATE || EnableDismountentities) && !player.getPassengers().isEmpty()) {
+                for (Entity passenger : player.getPassengers()) {
+
+                    player.removePassenger(passenger);
+
+                }
+
+            }
+
             for (Player ps : Bukkit.getOnlinePlayers()) {
                 // Some older spigot versions only support hidePlayer(player)
                 try {
@@ -83,4 +95,16 @@ public class UniversalSkinFactory extends SkinFactory {
         // return new LegacySkinRefresher();
         return new OldSkinRefresher();
     }
+    private void checkoptfile() {
+        File FileDisableDismoundPlayer = new File("plugins" + File.separator + "SkinsRestorer" + File.separator + "disablesdismoundplayer");
+        File FileEnableDismountentities = new File("plugins" + File.separator + "SkinsRestorer" + File.separator + "enablesdismoundentities");
+        if (FileDisableDismoundPlayer.exists())
+            DisableDismoundPlayer = true;
+
+        if (FileEnableDismountentities.exists())
+            EnableDismountentities = true;
+
+        checkoptfilechecked = true;
+    }
+
 }

--- a/src/main/java/skinsrestorer/bukkit/skinfactory/UniversalSkinFactory.java
+++ b/src/main/java/skinsrestorer/bukkit/skinfactory/UniversalSkinFactory.java
@@ -1,7 +1,10 @@
 package skinsrestorer.bukkit.skinfactory;
 
 import lombok.RequiredArgsConstructor;
+import skinsrestorer.shared.storage.Config;
+
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
@@ -21,10 +24,21 @@ public class UniversalSkinFactory extends SkinFactory {
 
         Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> {
 
-        	//dismounts a player before refreshing, which prevents desync 
-        	if (player.getVehicle() != null) {
+        	//dismounts a player before refreshing, which prevents desync caused by riding a horse, or plugins that allow sitting
+        	if (Config.DISMOUNT_PLAYER_ON_UPDATE && player.getVehicle() != null) {
         		
         		player.getVehicle().removePassenger(player);
+
+        	}
+        	
+        	//dismounts all entities riding the player, preventing desync from plugins that allow players to mount each other
+        	if (Config.DISMOUNT_PASSENGERS_ON_UPDATE && !player.getPassengers().isEmpty()) {
+        		
+        		for (Entity passenger : player.getPassengers()) {
+        		
+        			player.removePassenger(passenger);
+        			
+        		}
 
         	}
         	

--- a/src/main/java/skinsrestorer/shared/storage/Config.java
+++ b/src/main/java/skinsrestorer/shared/storage/Config.java
@@ -38,6 +38,8 @@ public class Config {
     public static boolean UPDATER_ENABLED = true;
     public static boolean UPDATER_PERIODIC = true;
     public static boolean DEBUG = false;
+    public static boolean DISMOUNT_PLAYER_ON_UPDATE = false;
+    public static boolean DISMOUNT_PASSENGERS_ON_UPDATE = false;
 
 
     // UPCOMING MULTIPLE LANGUAGE SUPPORT
@@ -80,6 +82,8 @@ public class Config {
         UPDATER_ENABLED = config.getBoolean("Updater.Enabled");
         UPDATER_PERIODIC = config.getBoolean("Updater.PeriodicChecks", UPDATER_PERIODIC);
         DEBUG = config.getBoolean("Debug", DEBUG);
+        DISMOUNT_PLAYER_ON_UPDATE = config.getBoolean("DismountPlayerOnSkinUpdate", DISMOUNT_PLAYER_ON_UPDATE);
+        DISMOUNT_PASSENGERS_ON_UPDATE = config.getBoolean("DismountPassengersOnSkinUpdate", DISMOUNT_PASSENGERS_ON_UPDATE);
 
         if (!CUSTOM_GUI_ENABLED)
             CUSTOM_GUI_ONLY = false;

--- a/src/main/java/skinsrestorer/shared/storage/Config.java
+++ b/src/main/java/skinsrestorer/shared/storage/Config.java
@@ -40,6 +40,7 @@ public class Config {
     public static boolean DEBUG = false;
     public static boolean DISMOUNT_PLAYER_ON_UPDATE = true;
     public static boolean DISMOUNT_PASSENGERS_ON_UPDATE = false;
+    public static boolean REMOUNT_PLAYER_ON_UPDATE = false;
 
 
     // UPCOMING MULTIPLE LANGUAGE SUPPORT
@@ -83,6 +84,7 @@ public class Config {
         UPDATER_PERIODIC = config.getBoolean("Updater.PeriodicChecks", UPDATER_PERIODIC);
         DEBUG = config.getBoolean("Debug", DEBUG);
         DISMOUNT_PLAYER_ON_UPDATE = config.getBoolean("DismountPlayerOnSkinUpdate", DISMOUNT_PLAYER_ON_UPDATE);
+        REMOUNT_PLAYER_ON_UPDATE = config.getBoolean("RemountPlayerOnSkinUpdate", REMOUNT_PLAYER_ON_UPDATE);
         DISMOUNT_PASSENGERS_ON_UPDATE = config.getBoolean("DismountPassengersOnSkinUpdate", DISMOUNT_PASSENGERS_ON_UPDATE);
 
         if (!CUSTOM_GUI_ENABLED)

--- a/src/main/java/skinsrestorer/shared/storage/Config.java
+++ b/src/main/java/skinsrestorer/shared/storage/Config.java
@@ -38,7 +38,7 @@ public class Config {
     public static boolean UPDATER_ENABLED = true;
     public static boolean UPDATER_PERIODIC = true;
     public static boolean DEBUG = false;
-    public static boolean DISMOUNT_PLAYER_ON_UPDATE = false;
+    public static boolean DISMOUNT_PLAYER_ON_UPDATE = true;
     public static boolean DISMOUNT_PASSENGERS_ON_UPDATE = false;
 
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -121,7 +121,7 @@ UseOldSkinHelp: false
 DisablePrefix: false
 
 # Dismounts a mounted (on a horse, or sitting) player when they a skin is updated, preventing players from becoming desynced.
-DismountPlayerOnSkinUpdate: false
+DismountPlayerOnSkinUpdate: tue
 
 # Dismounts all passengers mounting a player (such as plugins that let you ride another player), preventing those players from becoming desynced.
 DismountPassengersOnSkinUpdate: false

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -123,6 +123,9 @@ DisablePrefix: false
 # Dismounts a mounted (on a horse, or sitting) player when they a skin is updated, preventing players from becoming desynced.
 DismountPlayerOnSkinUpdate: true
 
+# Remounts a player that was dismounted after a skin update. This is only recommended if you do not use plugins that allow you ride other players, or use sit. Otherwise you could get errors or players could be kicked for flying.
+RemountPlayerOnSkinUpdate: false
+
 # Dismounts all passengers mounting a player (such as plugins that let you ride another player), preventing those players from becoming desynced.
 DismountPassengersOnSkinUpdate: false
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -121,7 +121,7 @@ UseOldSkinHelp: false
 DisablePrefix: false
 
 # Dismounts a mounted (on a horse, or sitting) player when they a skin is updated, preventing players from becoming desynced.
-DismountPlayerOnSkinUpdate: tue
+DismountPlayerOnSkinUpdate: true
 
 # Dismounts all passengers mounting a player (such as plugins that let you ride another player), preventing those players from becoming desynced.
 DismountPassengersOnSkinUpdate: false

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -120,6 +120,12 @@ UseOldSkinHelp: false
 #Ignore messages.yml 'PREFIX ='
 DisablePrefix: false
 
+# Dismounts a mounted (on a horse, or sitting) player when they a skin is updated, preventing players from becoming desynced.
+DismountPlayerOnSkinUpdate: false
+
+# Dismounts all passengers mounting a player (such as plugins that let you ride another player), preventing those players from becoming desynced.
+DismountPassengersOnSkinUpdate: false
+
   ################
   # DEV's corner #
   ################


### PR DESCRIPTION
I have adjusted the code that actually applies a player's skin to dismount a player right before applying the update skin. This fixes #289 and possibly other unknown desync issues.

I have only tested it on paper, because as far as I know that was the only server that experienced this issue. Additonal testing is appreciated.

I have successfully tested it on a server with 15+ players, we have noticed no TPS drops when using /skin, or any other issues.