### PR TITLE
Fix ViaBackwards incompatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,10 @@
             <id>velocity-repo</id>
             <url>https://repo.velocitypowered.com/snapshots/</url>
         </repository>
+        <repository>
+            <id>viaversion-repo</id>
+            <url>https://repo.viaversion.com</url>
+        </repository>
     </repositories>
     <dependencies>
         <!-- Spigot API -->
@@ -190,6 +194,20 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>8.0.21</version>
+        </dependency>
+        <!-- ViaBackwards (needed as a dependency to to fix 1.16.1 -> 1.15.2) -->
+        <dependency>
+            <groupId>nl.matsv</groupId>
+            <artifactId>viabackwards-core</artifactId>
+            <version>3.2.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- ViaVersion -->
+        <dependency>
+            <groupId>us.myles</groupId>
+            <artifactId>viaversion</artifactId>
+            <version>3.2.0</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/skinsrestorer/bukkit/skinfactory/UniversalSkinFactory.java
+++ b/src/main/java/skinsrestorer/bukkit/skinfactory/UniversalSkinFactory.java
@@ -5,10 +5,12 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+import skinsrestorer.bukkit.SkinsRestorer;
 import skinsrestorer.shared.storage.Config;
 
 import java.io.File;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 
 @RequiredArgsConstructor
 public class UniversalSkinFactory extends SkinFactory {
@@ -91,12 +93,11 @@ public class UniversalSkinFactory extends SkinFactory {
     private static Consumer<Player> detectRefresh() {
         // force OldSkinRefresher for unsupported plugins (ViaVersion & other ProtocolHack).
         // todo: reuse code
-        File ViaVersion = new File("plugins" + File.separator + "ViaVersion");
-        File ViaBackwards = new File("plugins" + File.separator + "ViaBackwards");
-        File ViaRewind = new File("plugins" + File.separator + "ViaRewind");
-        File ProtocolSupport = new File("plugins" + File.separator + "ProtocolSupport.jar");
-        if (ViaVersion.exists() || ViaBackwards.exists() || ViaRewind.exists() || ProtocolSupport.exists()) {
-            System.out.println("[SkinsRestorer] INFO: Unsupported plugin (ViaVersion) detected, forcing OldSkinRefresher");
+        // No need to check for all three Vias as ViaVersion has to be installed for the other two to work.
+        boolean ViaVersionExists = SkinsRestorer.getInstance().getServer().getPluginManager().isPluginEnabled("ViaVersion");
+        boolean ProtocolSupportExists = SkinsRestorer.getInstance().getServer().getPluginManager().isPluginEnabled("ProtocolSupport");
+        if (ViaVersionExists || ProtocolSupportExists) {
+            SkinsRestorer.getInstance().getLogger().log(Level.INFO, "Unsupported plugin (ViaVersion or ProtocolSupport) detected, forcing OldSkinRefresher");
             return new OldSkinRefresher();
         }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ version: ${project.version}
 description: ${project.description}
 website: https://skinsrestorer.net/
 authors: [Th3Tr0LLeR, McLive, DoNotSpamPls, knat]
+softdepend: ["ViaBackwards"]
 api-version: 1.13
 commands:
   skin:


### PR DESCRIPTION
As ViaVersion does not wish to implement a workaround, I've implemented the fix into SkinsRestorer without being too invasive on the current code. If the client is detected as 1.15.2 or lower, it directly sends the respawn packet to ViaVersion's pipeline in order to bypass their workaround.