### PR TITLE
Mysql fix

### DIFF
--- a/src/main/java/net/skinsrestorer/shared/storage/MySQL.java
+++ b/src/main/java/net/skinsrestorer/shared/storage/MySQL.java
@@ -65,18 +65,11 @@ public class MySQL {
     }
 
     public Connection openConnection() throws SQLException {
-        try {
-            Connection con = null;
-            Class.forName("com.mysql.cj.jdbc.Driver");
-            con = DriverManager.getConnection("jdbc:mysql://" + host + ":" + port + "/" + database + "?" + options, username, password);
+        com.mysql.cj.jdbc.Driver.getOSName();
+        con = DriverManager.getConnection("jdbc:mysql://" + host + ":" + port + "/" + database + "?" + options, username, password);
 
-            System.out.println("[SkinsRestorer] Connected to MySQL!");
-            this.con = con;
-            return con;
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-        }
-        return null;
+        System.out.println("[SkinsRestorer] Connected to MySQL!");
+        return con;
     }
 
     public Connection getConnection() {

--- a/src/main/java/net/skinsrestorer/shared/storage/MySQL.java
+++ b/src/main/java/net/skinsrestorer/shared/storage/MySQL.java
@@ -101,16 +101,14 @@ public class MySQL {
 
     private PreparedStatement prepareStatement(Connection conn, String query, Object... vars) {
         try {
-            try (PreparedStatement ps = conn.prepareStatement(query)) {
-                int i = 0;
-                if (query.contains("?") && vars.length != 0)
-                    for (Object obj : vars) {
-                        i++;
-                        ps.setObject(i, obj);
-                    }
-                return ps;
-            }
-
+            PreparedStatement ps = conn.prepareStatement(query);
+            int i = 0;
+            if (query.contains("?") && vars.length != 0)
+                for (Object obj : vars) {
+                    i++;
+                    ps.setObject(i, obj);
+                }
+            return ps;
         } catch (SQLException e) {
             System.out.println("[SkinsRestorer] MySQL error: " + e.getMessage());
         }


### PR DESCRIPTION
Somewhere there is still a problem which causes:
```
[11:56:23 INFO]: [SkinsRestorer] MySQL error: No operations allowed after statement closed.
[11:56:23 WARN]: java.sql.SQLException: No operations allowed after statement closed.
[11:56:23 WARN]:        at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:965)
[11:56:23 WARN]:        at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:898)
[11:56:23 WARN]:        at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:887)
[11:56:23 WARN]:        at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:861)
[11:56:23 WARN]:        at com.mysql.jdbc.StatementImpl.checkClosed(StatementImpl.java:442)
[11:56:23 WARN]:        at com.mysql.jdbc.PreparedStatement.execute(PreparedStatement.java:1129)
[11:56:23 WARN]:        at net.skinsrestorer.shared.storage.MySQL.execute(MySQL.java:126)
[11:56:23 WARN]:        at net.skinsrestorer.shared.storage.SkinStorage.setSkinData(SkinStorage.java:453)
[11:56:23 WARN]:        at net.skinsrestorer.shared.storage.SkinStorage.setSkinData(SkinStorage.java:482)
[11:56:23 WARN]:        at net.skinsrestorer.shared.storage.SkinStorage.getOrCreateSkinForPlayer(SkinStorage.java:170)
[11:56:23 WARN]:        at net.skinsrestorer.bukkit.listener.PlayerJoin.lambda$onJoin$0(PlayerJoin.java:59)
[11:56:23 WARN]:        at org.bukkit.craftbukkit.v1_12_R1.scheduler.CraftTask.run(CraftTask.java:64)
[11:56:23 WARN]:        at org.bukkit.craftbukkit.v1_12_R1.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:52)
[11:56:23 WARN]:        at com.destroystokyo.paper.ServerSchedulerReportingWrapper.run(ServerSchedulerReportingWrapper.java:22)
[11:56:23 WARN]:        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
[11:56:23 WARN]:        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
[11:56:23 WARN]:        at java.lang.Thread.run(Unknown Source)
[11:56:23 INFO]: [SkinsRestorer] MySQL error: No operations allowed after statement closed.
```