### PR TITLE
Feature/improved name check

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -38,14 +38,14 @@ If applicable, add screenshots to help explain your problem.
 **On what platform does your server run? (Bungeecord/Spigot/Bukkit)**
 
 **What version? Do NOT answer LATEST**
-* SkinsRestorer: 13.
-* Spigot version:
+* SkinsRestorer: 
+* Spigot version: 
 * Bungeecord version: 
 * IF bungee, did you put the plugin on all servers: Yes / No
 * Java: 8
-* plugin list bungee & spigot:
-* MinecraftLauncher?:
-* if multiverse, (censored) worlds file:
+* plugin list bungee & spigot: 
+* MinecraftLauncher?: 
+* if multiverse, (censored) worlds file: 
 
 ## Logs
 Replace the links below by a paste of your startup logs (if you run a **Bungeecord** server, please send startup logs from **Bungeecord *AND* Spigot/Bukkit**)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See [Contributors](https://github.com/SkinsRestorer/SkinsRestorerX/graphs/contri
 <dependency>
     <groupId>net.skinsrestorer</groupId>
     <artifactId>skinsrestorer</artifactId>
-    <version>14.0.0-SNAPSHOT</version>
+    <version>14.0.0</version>
 </dependency>
 ````
 

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
             <artifactId>bstats-sponge</artifactId>
             <version>2.2.1</version>
         </dependency>
-        <!-- bStats for Sponge -->
+        <!-- bStats for Velocity -->
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-velocity</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,18 @@
                             <pattern>com.cryptomorin.xseries</pattern>
                             <shadedPattern>net.skinsrestorer.shade.xseries</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>io.papermc.lib</pattern>
+                            <shadedPattern>net.skinsrestorer.shade.paperlib</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.mysql</pattern>
+                            <shadedPattern>net.skinsrestorer.shade.mysql</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>co.aikar.timings.lib</pattern>
+                            <shadedPattern>net.skinsrestorer.shade.timingslib</shadedPattern>
+                        </relocation>
                     </relocations>
                 </configuration>
                 <executions>
@@ -154,7 +166,11 @@
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
-            <id>bungeecord-repo</id>
+            <id>papermc</id>
+            <url>https://papermc.io/repo/repository/maven-public/</url>
+        </repository>
+        <repository>
+            <id>bungeecord</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
         <repository>
@@ -162,15 +178,15 @@
             <url>https://repo.spongepowered.org/maven</url>
         </repository>
         <repository>
-            <id>minecraft-repo</id>
+            <id>minecraft</id>
             <url>https://libraries.minecraft.net</url>
         </repository>
         <repository>
-            <id>codemc-repo</id>
+            <id>codemc</id>
             <url>https://repo.codemc.org/repository/maven-public</url>
         </repository>
         <repository>
-            <id>inventive-repo</id>
+            <id>inventive</id>
             <url>https://repo.inventivetalent.org/content/groups/public/</url>
         </repository>
         <repository>
@@ -178,11 +194,11 @@
             <url>https://repo.aikar.co/content/groups/aikar/</url>
         </repository>
         <repository>
-            <id>velocity-repo</id>
+            <id>velocity</id>
             <url>https://repo.velocitypowered.com/snapshots/</url>
         </repository>
         <repository>
-            <id>viaversion-repo</id>
+            <id>viaversion</id>
             <url>https://repo.viaversion.com</url>
         </repository>
     </repositories>
@@ -222,7 +238,6 @@
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-config</artifactId>
             <version>1.16-R0.4</version>
-            <scope>compile</scope>
         </dependency>
         <!-- Sponge API -->
         <dependency>
@@ -250,21 +265,18 @@
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
             <version>2.2.1</version>
-            <scope>compile</scope>
         </dependency>
         <!-- bStats for BungeeCord -->
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bungeecord</artifactId>
             <version>2.2.1</version>
-            <scope>compile</scope>
         </dependency>
         <!-- bStats for Sponge -->
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-sponge</artifactId>
             <version>2.2.1</version>
-            <scope>compile</scope>
         </dependency>
         <!-- bStats for Sponge -->
         <dependency>
@@ -348,6 +360,18 @@
             <groupId>com.github.cryptomorin</groupId>
             <artifactId>XSeries</artifactId>
             <version>7.8.0</version>
+        </dependency>
+        <!-- PaperLib -->
+        <dependency>
+            <groupId>io.papermc</groupId>
+            <artifactId>paperlib</artifactId>
+            <version>1.0.6</version>
+        </dependency>
+        <!-- Timings Lib -->
+        <dependency>
+            <groupId>co.aikar</groupId>
+            <artifactId>minecraft-timings</artifactId>
+            <version>1.0.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>net.skinsrestorer</groupId>
     <artifactId>skinsrestorer</artifactId>
-    <version>14.0.0</version>
+    <version>14.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>SkinsRestorer</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>net.skinsrestorer</groupId>
     <artifactId>skinsrestorer</artifactId>
-    <version>14.0.0-SNAPSHOT</version>
+    <version>14.0.0</version>
     <packaging>jar</packaging>
 
     <name>SkinsRestorer</name>

--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,13 @@
             <version>2.2.1</version>
             <scope>compile</scope>
         </dependency>
+        <!-- bStats for Sponge -->
+        <dependency>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-velocity</artifactId>
+            <version>2.2.1</version>
+            <scope>compile</scope>
+        </dependency>
         <!-- Spiget Updater for Bukkit -->
         <dependency>
             <groupId>org.inventivetalent.spiget-update</groupId>

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,8 @@
   ],
   "reviewers": [
     "xknat"
+  ],
+  "ignoreDeps": [
+    "us.myles:viaversion"
   ]
 }

--- a/src/main/java/net/skinsrestorer/api/SkinsRestorerAPI.java
+++ b/src/main/java/net/skinsrestorer/api/SkinsRestorerAPI.java
@@ -35,7 +35,8 @@ import net.skinsrestorer.shared.utils.MojangAPI;
  */
 @SuppressWarnings({"unused"})
 public class SkinsRestorerAPI {
-    private static @Getter SkinsRestorerAPI api;
+    private static @Getter
+    SkinsRestorerAPI api;
     private final MojangAPI mojangAPI;
     private final SkinStorage skinStorage;
     private final SRPlugin plugin;
@@ -82,7 +83,7 @@ public class SkinsRestorerAPI {
 
     @Beta
     public void applySkin(PlayerWrapper player, Object props) {
-        this.applySkin(player);
+        applySkin(player);
     }
 
     @Beta

--- a/src/main/java/net/skinsrestorer/api/bukkit/BukkitHeadAPI.java
+++ b/src/main/java/net/skinsrestorer/api/bukkit/BukkitHeadAPI.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
@@ -32,6 +32,8 @@ import java.util.Objects;
 import java.util.UUID;
 
 public class BukkitHeadAPI {
+    private BukkitHeadAPI() {}
+
     public static void setSkull(ItemStack head, String b64stringTexture) {
         GameProfile profile = new GameProfile(UUID.randomUUID(), null);
         PropertyMap propertyMap = profile.getProperties();

--- a/src/main/java/net/skinsrestorer/bukkit/SkinsGUI.java
+++ b/src/main/java/net/skinsrestorer/bukkit/SkinsGUI.java
@@ -189,9 +189,9 @@ public class SkinsGUI extends ItemStack implements Listener {
             switch (Objects.requireNonNull(XMaterial.matchXMaterial(currentItem))) {
                 case PLAYER_HEAD:
                     Bukkit.getScheduler().runTaskAsynchronously(SkinsRestorer.getInstance(), () -> {
-                                String skin = Objects.requireNonNull(currentItem.getItemMeta()).getDisplayName();
-                                plugin.requestSkinSetFromBungeeCord(player, skin);
-                            });
+                        String skin = Objects.requireNonNull(currentItem.getItemMeta()).getDisplayName();
+                        plugin.requestSkinSetFromBungeeCord(player, skin);
+                    });
                     player.closeInventory();
                     break;
                 case RED_STAINED_GLASS_PANE:

--- a/src/main/java/net/skinsrestorer/bukkit/SkinsRestorer.java
+++ b/src/main/java/net/skinsrestorer/bukkit/SkinsRestorer.java
@@ -395,11 +395,14 @@ public class SkinsRestorer extends JavaPlugin {
     private void checkBungeeMode() {
         bungeeEnabled = false;
         try {
-            bungeeEnabled = getServer().spigot().getConfig().getBoolean("settings.bungeecord");
-
+            try {
+                bungeeEnabled = getServer().spigot().getConfig().getBoolean("settings.bungeecord");
+            } catch (NoSuchMethodError ignored) {
+                this.srLogger.logAlways(Level.WARNING, "It is not recommended to use non spigot implementations! Use Paper/Spigot for SkinsRestorer! ");
+            }
             // sometimes it does not get the right "bungeecord: true" setting
             // we will try it again with the old function from SR 13.3
-            if (!bungeeEnabled) {
+            if (!bungeeEnabled && new File("spigot.yml").exists()) {
                 bungeeEnabled = YamlConfiguration.loadConfiguration(new File("spigot.yml")).getBoolean("settings.bungeecord");
             }
 

--- a/src/main/java/net/skinsrestorer/bukkit/SkinsRestorer.java
+++ b/src/main/java/net/skinsrestorer/bukkit/SkinsRestorer.java
@@ -25,6 +25,7 @@ import co.aikar.commands.BukkitCommandIssuer;
 import co.aikar.commands.ConditionFailedException;
 import co.aikar.commands.PaperCommandManager;
 import com.google.common.annotations.Beta;
+import io.papermc.lib.PaperLib;
 import lombok.Getter;
 import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.SkinsRestorerAPI;
@@ -57,31 +58,32 @@ import java.util.logging.Level;
 
 @SuppressWarnings("Duplicates")
 public class SkinsRestorer extends JavaPlugin {
-    private static @Getter
-    SkinsRestorer instance;
-    private final @Getter
-    String configPath = getDataFolder().getPath();
-    private @Getter
-    SkinFactory factory;
-    private @Getter
-    UpdateChecker updateChecker;
-    private @Getter
+    @Getter
+    private static SkinsRestorer instance;
+    @Getter
+    private final String configPath = getDataFolder().getPath();
+    @Getter
+    private SkinFactory factory;
+    @Getter
+    private UpdateChecker updateChecker;
+    @Getter
+    private
     boolean bungeeEnabled;
     private boolean updateDownloaded = false;
     private UpdateDownloaderGithub updateDownloader;
     private CommandSender console;
-    private @Getter
-    SRLogger srLogger;
-    private @Getter
-    SkinStorage skinStorage;
-    private @Getter
-    MojangAPI mojangAPI;
-    private @Getter
-    MineSkinAPI mineSkinAPI;
-    private @Getter
-    SkinsRestorerAPI skinsRestorerBukkitAPI;
-    private @Getter
-    SkinCommand skinCommand;
+    @Getter
+    private SRLogger srLogger;
+    @Getter
+    private SkinStorage skinStorage;
+    @Getter
+    private MojangAPI mojangAPI;
+    @Getter
+    private MineSkinAPI mineSkinAPI;
+    @Getter
+    private SkinsRestorerAPI skinsRestorerBukkitAPI;
+    @Getter
+    private SkinCommand skinCommand;
 
     private static Map<String, Property> convertToObject(byte[] byteArr) {
         Map<String, Property> map = new TreeMap<>();
@@ -106,7 +108,8 @@ public class SkinsRestorer extends JavaPlugin {
     public void onEnable() {
         console = getServer().getConsoleSender();
         srLogger = new SRLogger(getDataFolder());
-        File UPDATER_DISABLED = new File(this.configPath, "noupdate.txt");
+
+        File updaterDisabled = new File(configPath, "noupdate.txt");
 
         int pluginId = 1669; // SkinsRestorer's ID on bStats, for Bukkit
         Metrics metrics = new Metrics(this, pluginId);
@@ -141,19 +144,19 @@ public class SkinsRestorer extends JavaPlugin {
         checkBungeeMode();
 
         // Check for updates
-        if (!UPDATER_DISABLED.exists()) {
-            this.updateChecker = new UpdateCheckerGitHub(2124, this.getDescription().getVersion(), this.srLogger, "SkinsRestorerUpdater/Bukkit");
-            this.updateDownloader = new UpdateDownloaderGithub(this);
-            this.checkUpdate(bungeeEnabled);
+        if (!updaterDisabled.exists()) {
+            updateChecker = new UpdateCheckerGitHub(2124, getDescription().getVersion(), srLogger, "SkinsRestorerUpdater/Bukkit");
+            updateDownloader = new UpdateDownloaderGithub(this);
+            checkUpdate(bungeeEnabled);
 
-            this.getServer().getScheduler().runTaskTimerAsynchronously(this, () -> {
-                this.checkUpdate(bungeeEnabled, false);
+            getServer().getScheduler().runTaskTimerAsynchronously(this, () -> {
+                checkUpdate(bungeeEnabled, false);
             }, 20 * 60 * 10, 20 * 60 * 10);
         } else {
             srLogger.logAlways(Level.INFO, "Updater Disabled");
         }
 
-        this.skinStorage = new SkinStorage(SkinStorage.Platform.BUKKIT);
+        skinStorage = new SkinStorage(SkinStorage.Platform.BUKKIT);
 
         // Init SkinsGUI click listener even when on bungee
         Bukkit.getPluginManager().registerEvents(new SkinsGUI(this), this);
@@ -168,9 +171,9 @@ public class SkinsRestorer extends JavaPlugin {
                     DataInputStream in = new DataInputStream(new ByteArrayInputStream(message));
 
                     try {
-                        String subchannel = in.readUTF();
+                        String subChannel = in.readUTF();
 
-                        if (subchannel.equalsIgnoreCase("SkinUpdate")) {
+                        if (subChannel.equalsIgnoreCase("SkinUpdate")) {
                             try {
                                 factory.applySkin(player, this.skinStorage.createProperty(in.readUTF(), in.readUTF(), in.readUTF()));
                             } catch (IOException ignored) {

--- a/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
@@ -222,7 +222,7 @@ public class SkinCommand extends BaseCommand {
     // because default skin names shouldn't be saved as the users custom skin
     //todo align setSkin with the other platforms so that it match and can be merged on a later stage!
     private boolean setSkin(CommandSender sender, Player p, String skin, boolean save, boolean clear) {
-        if (skin.equalsIgnoreCase("null") || !C.validUsername(skin) && !C.validUrl(skin)) {
+        if (skin.equalsIgnoreCase("null") || !C.validMojangUsername(skin) && !C.validUrl(skin)) {
             sender.sendMessage(Locale.INVALID_PLAYER.replace("%player", skin));
             return false;
         }
@@ -246,7 +246,7 @@ public class SkinCommand extends BaseCommand {
 
         final String pName = p.getName();
         final String oldSkinName = plugin.getSkinStorage().getPlayerSkin(pName);
-        if (C.validUsername(skin)) {
+        if (C.validMojangUsername(skin)) {
             try {
                 if (save)
                     plugin.getSkinStorage().setPlayerSkin(pName, skin);

--- a/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
@@ -277,7 +277,7 @@ public class SkinCommand extends BaseCommand {
                 return false;
             }
 
-            if (!C.isAllowed(skin)) {
+            if (!C.allowedSkinUrl(skin)) {
                 sender.sendMessage(Locale.SKINURL_DISALLOWED);
                 CooldownStorage.resetCooldown(senderName);
                 return false;

--- a/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
@@ -141,7 +141,7 @@ public class SkinCommand extends BaseCommand {
                         return;
                     }
 
-                    if (!plugin.getSkinStorage().forceUpdateSkinData(skin)) {
+                    if (!plugin.getSkinStorage().UpdateSkinData(skin)) {
                         sender.sendMessage(Locale.ERROR_UPDATING_SKIN);
                         return;
                     }

--- a/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
@@ -253,6 +253,7 @@ public class SkinCommand extends BaseCommand {
 
                 //todo getOrCreateSkinForPlayer is nested and on different places around bungee/sponge/velocity
                 plugin.getFactory().applySkin(p, plugin.getSkinStorage().getOrCreateSkinForPlayer(skin, false));
+                if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
                 p.sendMessage(Locale.SKIN_CHANGE_SUCCESS);
 
                 return true;
@@ -291,6 +292,7 @@ public class SkinCommand extends BaseCommand {
                         Long.toString(System.currentTimeMillis() + (100L * 365 * 24 * 60 * 60 * 1000))); // "generate" and save skin for 100 years
                 plugin.getSkinStorage().setPlayerSkin(pName, skinentry); // set player to "whitespaced" name then reload skin
                 SkinsRestorer.getInstance().getFactory().applySkin(p, plugin.getSkinStorage().getSkinData(skinentry));
+                if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
                 p.sendMessage(Locale.SKIN_CHANGE_SUCCESS);
                 return true;
             } catch (SkinRequestException e) {

--- a/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
@@ -54,7 +54,7 @@ public class SkinCommand extends BaseCommand {
     @Default
     @SuppressWarnings({"deprecation"})
     public void onDefault(CommandSender sender) {
-        this.onHelp(sender, this.getCurrentCommandManager().generateCommandHelp());
+        onHelp(sender, getCurrentCommandManager().generateCommandHelp());
     }
 
     @Default
@@ -63,7 +63,7 @@ public class SkinCommand extends BaseCommand {
     @Syntax("%SyntaxDefaultCommand")
     @SuppressWarnings({"unused"})
     public void onSkinSetShort(Player p, @Single String skin) {
-        this.onSkinSetOther(p, new OnlinePlayer(p), skin);
+        onSkinSetOther(p, new OnlinePlayer(p), skin);
     }
 
     @HelpCommand
@@ -79,7 +79,7 @@ public class SkinCommand extends BaseCommand {
     @CommandPermission("%skinClear")
     @Description("%helpSkinClear")
     public void onSkinClear(Player p) {
-        this.onSkinClearOther(p, new OnlinePlayer(p));
+        onSkinClearOther(p, new OnlinePlayer(p));
     }
 
     @Subcommand("clear")
@@ -101,7 +101,7 @@ public class SkinCommand extends BaseCommand {
             // remove users defined skin from database
             plugin.getSkinStorage().removePlayerSkin(pName);
 
-            if (this.setSkin(sender, p, skin, false, true)) {
+            if (setSkin(sender, p, skin, false, true)) {
                 if (sender == p)
                     sender.sendMessage(Locale.SKIN_CLEAR_SUCCESS);
                 else
@@ -115,7 +115,7 @@ public class SkinCommand extends BaseCommand {
     @Description("%helpSkinUpdate")
     @SuppressWarnings({"unused"})
     public void onSkinUpdate(Player p) {
-        this.onSkinUpdateOther(p, new OnlinePlayer(p));
+        onSkinUpdateOther(p, new OnlinePlayer(p));
     }
 
     @Subcommand("update")
@@ -155,8 +155,8 @@ public class SkinCommand extends BaseCommand {
                 return;
             }
 
-            // todo Use its own code instead of bloat this.setskin
-            if (this.setSkin(sender, p, skin, false, false)) {
+            // todo Use its own code instead of bloat setskin
+            if (setSkin(sender, p, skin, false, false)) {
                 if (sender == p)
                     sender.sendMessage(Locale.SUCCESS_UPDATING_SKIN);
                 else
@@ -171,7 +171,7 @@ public class SkinCommand extends BaseCommand {
     @Syntax("%SyntaxSkinSet")
     public void onSkinSet(Player p, String[] skin) {
         if (skin.length > 0) {
-            this.onSkinSetOther(p, new OnlinePlayer(p), skin[0]);
+            onSkinSetOther(p, new OnlinePlayer(p), skin[0]);
         } else {
             throw new InvalidCommandArgument(MessageKeys.INVALID_SYNTAX);
         }
@@ -192,7 +192,7 @@ public class SkinCommand extends BaseCommand {
                 }
             }
 
-            if (this.setSkin(sender, p, skin) && !(sender == p))
+            if (setSkin(sender, p, skin) && !(sender == p))
                 sender.sendMessage(Locale.ADMIN_SET_SKIN.replace("%player", p.getName()));
         });
     }
@@ -205,7 +205,7 @@ public class SkinCommand extends BaseCommand {
     public void onSkinSetUrl(Player p, String[] url) {
         if (url.length > 0) {
             if (C.validUrl(url[0])) {
-                this.onSkinSetOther(p, new OnlinePlayer(p), url[0]);
+                onSkinSetOther(p, new OnlinePlayer(p), url[0]);
             } else {
                 p.sendMessage(Locale.ERROR_INVALID_URLSKIN);
             }
@@ -215,7 +215,7 @@ public class SkinCommand extends BaseCommand {
     }
 
     private boolean setSkin(CommandSender sender, Player p, String skin) {
-        return this.setSkin(sender, p, skin, true, false);
+        return setSkin(sender, p, skin, true, false);
     }
 
     // if save is false, we won't save the skin skin name
@@ -276,7 +276,7 @@ public class SkinCommand extends BaseCommand {
                 return false;
             }
 
-            if (!C.AllowedUrlIfEnabled(skin)) {
+            if (!C.isAllowed(skin)) {
                 sender.sendMessage(Locale.SKINURL_DISALLOWED);
                 CooldownStorage.resetCooldown(senderName);
                 return false;
@@ -303,7 +303,7 @@ public class SkinCommand extends BaseCommand {
 
         // set CoolDown to ERROR_COOLDOWN and rollback to old skin on exception
         CooldownStorage.setCooldown(senderName, Config.SKIN_ERROR_COOLDOWN, TimeUnit.SECONDS);
-        this.rollback(p, oldSkinName, save);
+        rollback(p, oldSkinName, save);
         return false;
     }
 

--- a/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
@@ -141,7 +141,7 @@ public class SkinCommand extends BaseCommand {
                         return;
                     }
 
-                    if (!plugin.getSkinStorage().UpdateSkinData(skin)) {
+                    if (!plugin.getSkinStorage().updateSkinData(skin)) {
                         sender.sendMessage(Locale.ERROR_UPDATING_SKIN);
                         return;
                     }

--- a/src/main/java/net/skinsrestorer/bukkit/listener/PlayerJoin.java
+++ b/src/main/java/net/skinsrestorer/bukkit/listener/PlayerJoin.java
@@ -24,7 +24,6 @@ package net.skinsrestorer.bukkit.listener;
 import net.skinsrestorer.bukkit.SkinsRestorer;
 import net.skinsrestorer.shared.exception.SkinRequestException;
 import net.skinsrestorer.shared.storage.Config;
-import net.skinsrestorer.shared.storage.Locale;
 import net.skinsrestorer.shared.storage.SkinStorage;
 import net.skinsrestorer.shared.utils.C;
 import net.skinsrestorer.shared.utils.SRLogger;
@@ -48,29 +47,30 @@ public class PlayerJoin implements Listener {
             return;
 
         plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
-            try {
-                final SkinStorage skinStorage = plugin.getSkinStorage();
-                final Player player = e.getPlayer();
-                final String name = player.getName();
-                final String skin = skinStorage.getDefaultSkinNameIfEnabled(name);
-                Object texture;
 
+            final SkinStorage skinStorage = plugin.getSkinStorage();
+            final Player player = e.getPlayer();
+            final String name = player.getName();
+            final String skin = skinStorage.getDefaultSkinNameIfEnabled(name);
+            Object texture = null;
+
+            try {
                 if (C.validUrl(skin)) {
                     texture = plugin.getMineSkinAPI().genSkin(skin);
                 } else {
                     texture = skinStorage.getOrCreateSkinForPlayer(skin, true);
                 }
-
-                if (texture == null) {
-                    //todo @xknat finish this (add perms etc)
-                    //player.sendMessage(Locale.PREFIX + "No skin for your account found. \nGet a skin by running /skin");
-                    return;
-                }
-
-                //Apply the skin
-                plugin.getFactory().applySkin(player, texture);
             } catch (SkinRequestException ignored) {
             }
+
+            if (texture == null) {
+                //todo @xknat finish this (add perms etc)
+                //player.sendMessage(Locale.PREFIX + "No skin for your account found. \nGet a skin by running /skin");
+                return;
+            }
+
+            //Apply the skin
+            plugin.getFactory().applySkin(player, texture);
         });
     }
 }

--- a/src/main/java/net/skinsrestorer/bukkit/listener/PlayerJoin.java
+++ b/src/main/java/net/skinsrestorer/bukkit/listener/PlayerJoin.java
@@ -24,6 +24,7 @@ package net.skinsrestorer.bukkit.listener;
 import net.skinsrestorer.bukkit.SkinsRestorer;
 import net.skinsrestorer.shared.exception.SkinRequestException;
 import net.skinsrestorer.shared.storage.Config;
+import net.skinsrestorer.shared.storage.Locale;
 import net.skinsrestorer.shared.storage.SkinStorage;
 import net.skinsrestorer.shared.utils.C;
 import net.skinsrestorer.shared.utils.SRLogger;
@@ -52,12 +53,22 @@ public class PlayerJoin implements Listener {
                 final Player player = e.getPlayer();
                 final String name = player.getName();
                 final String skin = skinStorage.getDefaultSkinNameIfEnabled(name);
+                Object texture;
 
                 if (C.validUrl(skin)) {
-                    plugin.getFactory().applySkin(player, plugin.getMineSkinAPI().genSkin(skin));
+                    texture = plugin.getMineSkinAPI().genSkin(skin);
                 } else {
-                    plugin.getFactory().applySkin(player, skinStorage.getOrCreateSkinForPlayer(skin, false));
+                    texture = skinStorage.getOrCreateSkinForPlayer(skin, true);
                 }
+
+                if (texture == null) {
+                    //todo @xknat finish this (add perms etc)
+                    //player.sendMessage(Locale.PREFIX + "No skin for your account found. \nGet a skin by running /skin");
+                    return;
+                }
+
+                //Apply the skin
+                plugin.getFactory().applySkin(player, texture);
             } catch (SkinRequestException ignored) {
             }
         });

--- a/src/main/java/net/skinsrestorer/bukkit/skinfactory/SkinFactory.java
+++ b/src/main/java/net/skinsrestorer/bukkit/skinfactory/SkinFactory.java
@@ -35,12 +35,12 @@ public interface SkinFactory {
      * @param props - Property Object
      */
     default void applySkin(final Player p, Object props) {
+        if (props == null)
+            return;
+
         // delay 1 servertick so we override online-mode
         Bukkit.getScheduler().scheduleSyncDelayedTask(SkinsRestorer.getInstance(), () -> {
             try {
-                if (props == null)
-                    return;
-
                 Object ep = ReflectionUtil.invokeMethod(p.getClass(), p, "getHandle");
                 Object profile = ReflectionUtil.invokeMethod(ep.getClass(), ep, "getProfile");
                 Object propMap = ReflectionUtil.invokeMethod(profile.getClass(), profile, "getProperties");

--- a/src/main/java/net/skinsrestorer/bukkit/skinfactory/UniversalSkinFactory.java
+++ b/src/main/java/net/skinsrestorer/bukkit/skinfactory/UniversalSkinFactory.java
@@ -130,7 +130,7 @@ public class UniversalSkinFactory implements SkinFactory {
     private void checkOptFile() {
         File fileDisableDismountPlayer = new File("plugins" + File.separator + "SkinsRestorer" + File.separator + "disablesdismountplayer");
         File fileEnableDismountEntities = new File("plugins" + File.separator + "SkinsRestorer" + File.separator + "enablesdismountentities");
-        File fileEnableRemountEntiteis = new File("plugins" + File.separator + "SkinsRestorer" + File.separator + "enablesremountentities");
+        File fileDisableRemountPlayer = new File("plugins" + File.separator + "SkinsRestorer" + File.separator + "disablesremountplayer");
 
         if (fileDisableDismountPlayer.exists())
             disableDismountPlayer = true;
@@ -138,8 +138,8 @@ public class UniversalSkinFactory implements SkinFactory {
         if (fileEnableDismountEntities.exists())
             enableDismountEntities = true;
 
-        if (fileEnableRemountEntiteis.exists())
-            enableRemountPlayer = true;
+        if (fileDisableRemountPlayer.exists())
+            enableRemountPlayer = false;
 
         checkOptFileChecked = true;
     }

--- a/src/main/java/net/skinsrestorer/bukkit/skinfactory/UniversalSkinFactory.java
+++ b/src/main/java/net/skinsrestorer/bukkit/skinfactory/UniversalSkinFactory.java
@@ -21,6 +21,7 @@
  */
 package net.skinsrestorer.bukkit.skinfactory;
 
+import io.papermc.lib.PaperLib;
 import lombok.RequiredArgsConstructor;
 import net.skinsrestorer.bukkit.SkinsRestorer;
 import net.skinsrestorer.shared.storage.Config;
@@ -59,9 +60,11 @@ public class UniversalSkinFactory implements SkinFactory {
             return new OldSkinRefresher();
         }
 
-        try {
-            return new PaperSkinRefresher();
-        } catch (ExceptionInInitializerError ignored) {
+        if (PaperLib.isPaper()) {
+            try {
+                return new PaperSkinRefresher();
+            } catch (ExceptionInInitializerError ignored) {
+            }
         }
 
         return new OldSkinRefresher();
@@ -73,7 +76,7 @@ public class UniversalSkinFactory implements SkinFactory {
             return;
 
         if (checkOptFileChecked)
-            this.checkOptFile();
+            checkOptFile();
 
         Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> {
             Entity vehicle = player.getVehicle();
@@ -117,12 +120,12 @@ public class UniversalSkinFactory implements SkinFactory {
             for (Player ps : Bukkit.getOnlinePlayers()) {
                 // Some older spigot versions only support hidePlayer(player)
                 try {
-                    ps.hidePlayer(this.plugin, player);
+                    ps.hidePlayer(plugin, player);
                 } catch (NoSuchMethodError ignored) {
                     ps.hidePlayer(player);
                 }
                 try {
-                    ps.showPlayer(this.plugin, player);
+                    ps.showPlayer(plugin, player);
                 } catch (NoSuchMethodError ignored) {
                     ps.showPlayer(player);
                 }

--- a/src/main/java/net/skinsrestorer/bukkit/skinfactory/UniversalSkinFactory.java
+++ b/src/main/java/net/skinsrestorer/bukkit/skinfactory/UniversalSkinFactory.java
@@ -46,8 +46,7 @@ public class UniversalSkinFactory implements SkinFactory {
         // Giving warning when using java 9+ regarding illegal reflection access
         final String version = System.getProperty("java.version");
         if (!version.startsWith("1."))
-            System.out.println("[SkinsRestorer] [!] WARNING [!] \n[SkinsRestorer] Below message can be IGNORED, we will fix this in a later release!");
-
+             System.out.println("[SkinsRestorer] [!] WARNING [!] \n[SkinsRestorer] Below message about \"Illegal reflective access\" can be IGNORED, we will fix this in a later release!");
 
         // force OldSkinRefresher for unsupported plugins (ViaVersion & other ProtocolHack).
         // todo: reuse code
@@ -103,14 +102,7 @@ public class UniversalSkinFactory implements SkinFactory {
 
             //dismounts all entities riding the player, preventing desync from plugins that allow players to mount each other
             if (Config.DISMOUNT_PASSENGERS_ON_UPDATE || enableDismountEntities) {
-                boolean haspassengers = false;
-                try {
-                    haspassengers = !player.getPassengers().isEmpty();
-                } catch (NoSuchMethodError e) {
-                    haspassengers = !player.getPassenger().isEmpty();
-                }
-
-                if (haspassengers) {
+                if (!player.isEmpty()) {
                     for (Entity passenger : player.getPassengers()) {
                         player.removePassenger(passenger);
                     }

--- a/src/main/java/net/skinsrestorer/bungee/SkinsRestorer.java
+++ b/src/main/java/net/skinsrestorer/bungee/SkinsRestorer.java
@@ -55,34 +55,32 @@ import java.util.logging.Level;
 
 @SuppressWarnings("Duplicates")
 public class SkinsRestorer extends Plugin implements SRPlugin {
-    private static @Getter
-    SkinsRestorer instance;
-    private final @Getter
-    String configPath = getDataFolder().getPath();
-    private @Getter
-    boolean multiBungee;
-    private @Getter
-    boolean outdated;
+    @Getter
+    private static SkinsRestorer instance;
+    @Getter
+    private final String configPath = getDataFolder().getPath();
+    @Getter
+    private boolean multiBungee;
+    @Getter
+    private boolean outdated;
     private CommandSender console;
     private UpdateChecker updateChecker;
-
-    private @Getter
-    SkinApplierBungee skinApplierBungee;
-
-    private @Getter
-    SkinStorage skinStorage;
-    private @Getter
-    MojangAPI mojangAPI;
-    private @Getter
-    MineSkinAPI mineSkinAPI;
-    private @Getter
-    SRLogger srLogger;
-    private @Getter
-    PluginMessageListener pluginMessageListener;
-    private @Getter
-    SkinCommand skinCommand;
-    private @Getter
-    SkinsRestorerAPI skinsRestorerBungeeAPI;
+    @Getter
+    private SkinApplierBungee skinApplierBungee;
+    @Getter
+    private SRLogger srLogger;
+    @Getter
+    private SkinStorage skinStorage;
+    @Getter
+    private MojangAPI mojangAPI;
+    @Getter
+    private MineSkinAPI mineSkinAPI;
+    @Getter
+    private PluginMessageListener pluginMessageListener;
+    @Getter
+    private SkinCommand skinCommand;
+    @Getter
+    private SkinsRestorerAPI skinsRestorerBungeeAPI;
 
     public String getVersion() {
         return getDescription().getVersion();
@@ -93,7 +91,7 @@ public class SkinsRestorer extends Plugin implements SRPlugin {
         srLogger = new SRLogger(getDataFolder());
         instance = this;
         console = getProxy().getConsole();
-        File UPDATER_DISABLED = new File(this.configPath, "noupdate.txt");
+        File updaterDisabled = new File(this.configPath, "noupdate.txt");
 
         int pluginId = 1686; // SkinsRestorer's ID on bStats, for Bungeecord
         Metrics metrics = new Metrics(this, pluginId);
@@ -102,7 +100,7 @@ public class SkinsRestorer extends Plugin implements SRPlugin {
         metrics.addCustomChart(new SingleLineChart("mojang_calls", MetricsCounter::collectMojangCalls));
         metrics.addCustomChart(new SingleLineChart("backup_calls", MetricsCounter::collectBackupCalls));
 
-        if (!UPDATER_DISABLED.exists()) {
+        if (!updaterDisabled.exists()) {
             this.updateChecker = new UpdateCheckerGitHub(2124, this.getDescription().getVersion(), this.srLogger, "SkinsRestorerUpdater/BungeeCord");
             this.checkUpdate(true);
 

--- a/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
@@ -286,7 +286,7 @@ public class SkinCommand extends BaseCommand {
                 return false;
             }
 
-            if (!C.AllowedUrlIfEnabled(skin)) {
+            if (!C.isAllowed(skin)) {
                 sender.sendMessage(TextComponent.fromLegacyText(Locale.SKINURL_DISALLOWED));
                 CooldownStorage.resetCooldown(senderName);
                 return false;

--- a/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
@@ -287,7 +287,7 @@ public class SkinCommand extends BaseCommand {
                 return false;
             }
 
-            if (!C.isAllowed(skin)) {
+            if (!C.allowedSkinUrl(skin)) {
                 sender.sendMessage(TextComponent.fromLegacyText(Locale.SKINURL_DISALLOWED));
                 CooldownStorage.resetCooldown(senderName);
                 return false;

--- a/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
@@ -258,6 +258,7 @@ public class SkinCommand extends BaseCommand {
                     plugin.getSkinApplierBungee().applySkin(p, skin, null);
                 }
 
+                if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
                 p.sendMessage(TextComponent.fromLegacyText(Locale.SKIN_CHANGE_SUCCESS)); //todo: should this not be sender? -> hidden skin update?? (maybe when p has no perms)
                 return true;
             } catch (SkinRequestException e) {
@@ -303,6 +304,7 @@ public class SkinCommand extends BaseCommand {
                         Long.toString(System.currentTimeMillis() + (100L * 365 * 24 * 60 * 60 * 1000))); // "generate" and save skin for 100 years
                 plugin.getSkinStorage().setPlayerSkin(pName, skinentry); // set player to "whitespaced" name then reload skin
                 plugin.getSkinApplierBungee().applySkin(new PlayerWrapper(p), plugin.getSkinsRestorerBungeeAPI());
+                if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
                 p.sendMessage(TextComponent.fromLegacyText(Locale.SKIN_CHANGE_SUCCESS));
 
                 return true;

--- a/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
@@ -144,7 +144,7 @@ public class SkinCommand extends BaseCommand {
                         return;
                     }
 
-                    if (!plugin.getSkinStorage().forceUpdateSkinData(skin)) {
+                    if (!plugin.getSkinStorage().UpdateSkinData(skin)) {
                         sender.sendMessage(TextComponent.fromLegacyText(Locale.ERROR_UPDATING_SKIN));
                         return;
                     }

--- a/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
@@ -223,7 +223,7 @@ public class SkinCommand extends BaseCommand {
     // if save is false, we won't save the skin skin name
     // because default skin names shouldn't be saved as the users custom skin
     private boolean setSkin(CommandSender sender, ProxiedPlayer p, String skin, boolean save, boolean clear) {
-        if (skin.equalsIgnoreCase("null") || !C.validUsername(skin) && !C.validUrl(skin)) {
+        if (skin.equalsIgnoreCase("null") || !C.validMojangUsername(skin) && !C.validUrl(skin)) {
             sender.sendMessage(TextComponent.fromLegacyText(Locale.INVALID_PLAYER.replace("%player", skin)));
             return false;
         }
@@ -247,7 +247,7 @@ public class SkinCommand extends BaseCommand {
 
         final String pName = p.getName();
         final String oldSkinName = plugin.getSkinStorage().getPlayerSkin(pName);
-        if (C.validUsername(skin)) {
+        if (C.validMojangUsername(skin)) {
             try {
                 plugin.getSkinStorage().getOrCreateSkinForPlayer(skin, false);
 

--- a/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
@@ -144,7 +144,7 @@ public class SkinCommand extends BaseCommand {
                         return;
                     }
 
-                    if (!plugin.getSkinStorage().UpdateSkinData(skin)) {
+                    if (!plugin.getSkinStorage().updateSkinData(skin)) {
                         sender.sendMessage(TextComponent.fromLegacyText(Locale.ERROR_UPDATING_SKIN));
                         return;
                     }

--- a/src/main/java/net/skinsrestorer/shared/storage/MySQL.java
+++ b/src/main/java/net/skinsrestorer/shared/storage/MySQL.java
@@ -74,21 +74,21 @@ public class MySQL {
 
     public Connection getConnection() {
         try {
-            if (con == null || !this.con.isValid(1)) {
+            if (con == null || !con.isValid(1)) {
                 System.out.println("[SkinsRestorer] MySQL connection lost! Creation a new one.");
-                con = this.openConnection();
+                con = openConnection();
             }
         } catch (SQLException e) {
             System.out.println("[SkinsRestorer] Could NOT connect to MySQL: " + e.getMessage());
         }
 
-        try (PreparedStatement stmt = this.con.prepareStatement("SELECT 1")) {
+        try (PreparedStatement stmt = con.prepareStatement("SELECT 1")) {
             stmt.execute();
         } catch (SQLException e) {
             System.out.println("[SkinsRestorer] MySQL SELECT 1 failed. Reconnecting");
 
             try {
-                con = this.openConnection();
+                con = openConnection();
                 return con;
             } catch (SQLException e1) {
                 System.out.println("[SkinsRestorer] Couldn't reconnect to MySQL.");
@@ -117,7 +117,7 @@ public class MySQL {
     }
 
     public void execute(final String query, final Object... vars) {
-        Connection conn = this.getConnection();
+        Connection conn = getConnection();
 
         try (PreparedStatement ps = prepareStatement(conn, query, vars)) {
             assert ps != null;
@@ -132,7 +132,7 @@ public class MySQL {
     }
 
     public CachedRowSet query(final String query, final Object... vars) {
-        Connection conn = this.getConnection();
+        Connection conn = getConnection();
         CachedRowSet rowSet = null;
 
         try {

--- a/src/main/java/net/skinsrestorer/shared/storage/SkinStorage.java
+++ b/src/main/java/net/skinsrestorer/shared/storage/SkinStorage.java
@@ -96,7 +96,7 @@ public class SkinStorage {
             //todo: add try for skinUrl
             try {
                 if (!C.validUrl(skin)) {
-                    this.getOrCreateSkinForPlayer(skin, false);
+                    getOrCreateSkinForPlayer(skin, false);
                 }
             } catch (SkinRequestException e) {
                 //removing skin from list
@@ -159,7 +159,7 @@ public class SkinStorage {
 
         // No cached skin found, get from MojangAPI, save and return
         try {
-            textures = this.getMojangAPI().getSkinProperty(this.getMojangAPI().getUUID(skin, true));
+            textures = getMojangAPI().getSkinProperty(getMojangAPI().getUUID(skin, true));
 
             if (textures == null)
                 throw new SkinRequestException(Locale.ERROR_NO_SKIN);
@@ -255,9 +255,9 @@ public class SkinStorage {
                     final String timestamp = crs.getString("timestamp");
 
                     if (updateOutdated && isOld(Long.parseLong(timestamp))) {
-                        final Object skin = this.getMojangAPI().getSkinProperty(this.getMojangAPI().getUUID(name, true));
+                        final Object skin = getMojangAPI().getSkinProperty(getMojangAPI().getUUID(name, true));
                         if (skin != null) {
-                            this.setSkinData(name, skin);
+                            setSkinData(name, skin);
                             return skin;
                         }
                     }
@@ -301,15 +301,15 @@ public class SkinStorage {
                 }
 
                 if (updateOutdated && isOld(Long.parseLong(timestamp))) {
-                    final Object skin = this.getMojangAPI().getSkinProperty(this.getMojangAPI().getUUID(name, true));
+                    final Object skin = getMojangAPI().getSkinProperty(getMojangAPI().getUUID(name, true));
 
                     if (skin != null) {
-                        this.setSkinData(name, skin);
+                        setSkinData(name, skin);
                         return skin;
                     }
                 }
 
-                return this.createProperty("textures", value, signature);
+                return createProperty("textures", value, signature);
 
             } catch (Exception e) {
                 removeSkinData(name);
@@ -320,7 +320,7 @@ public class SkinStorage {
     }
 
     public Object getSkinData(String name) {
-        return this.getSkinData(name, true);
+        return getSkinData(name, true);
     }
 
     /**
@@ -530,10 +530,10 @@ public class SkinStorage {
                     if (Config.CUSTOM_GUI_ONLY) { //Show only Config.CUSTOM_GUI_SKINS in the gui
                         for (String GuiSkins : Config.CUSTOM_GUI_SKINS) {
                             if (skinName.toLowerCase().contains(GuiSkins.toLowerCase()))
-                                list.put(skinName.toLowerCase(), this.getSkinData(skinName, false));
+                                list.put(skinName.toLowerCase(), getSkinData(skinName, false));
                         }
                     } else {
-                        list.put(skinName.toLowerCase(), this.getSkinData(skinName, false));
+                        list.put(skinName.toLowerCase(), getSkinData(skinName, false));
                     }
                 }
                 i++;
@@ -634,10 +634,10 @@ public class SkinStorage {
 
         //Update Skin
         try {
-            final Object textures = this.getMojangAPI().getSkinPropertyMojang(this.getMojangAPI().getUUIDMojang(skin));
+            final Object textures = getMojangAPI().getSkinPropertyMojang(getMojangAPI().getUUIDMojang(skin));
 
             if (textures != null) {
-                this.setSkinData(skin, textures);
+                setSkinData(skin, textures);
                 return true;
             }
         } catch (SkinRequestException e) {
@@ -672,7 +672,7 @@ public class SkinStorage {
             if (!Config.DEFAULT_SKINS_PREMIUM) {
                 // check if player is premium
                 try {
-                    if (this.getMojangAPI().getUUID(player, true) != null) {
+                    if (getMojangAPI().getUUID(player, true) != null) {
                         // player is premium, return his skin name instead of default skin
                         return player;
                     }
@@ -682,7 +682,7 @@ public class SkinStorage {
             }
 
             // return default skin name if user has no custom skin set or we want to clear to default
-            if (this.getPlayerSkin(player) == null || clear) {
+            if (getPlayerSkin(player) == null || clear) {
                 final List<String> skins = Config.DEFAULT_SKINS;
                 int r = 0;
                 if (skins.size() > 1)
@@ -698,7 +698,7 @@ public class SkinStorage {
             return player;
 
         // return the custom skin user has set
-        String skin = this.getPlayerSkin(player);
+        String skin = getPlayerSkin(player);
 
         // null if player has no custom skin, we'll return his name then
         return skin == null ? player : skin;

--- a/src/main/java/net/skinsrestorer/shared/storage/SkinStorage.java
+++ b/src/main/java/net/skinsrestorer/shared/storage/SkinStorage.java
@@ -158,21 +158,23 @@ public class SkinStorage {
             return textures;
 
         // No cached skin found, get from MojangAPI, save and return
-        try {
-            textures = getMojangAPI().getSkinProperty(getMojangAPI().getUUID(skin, true));
+        if (C.validMojangUsername(name)) {
+            try {
+                textures = getMojangAPI().getSkinProperty(getMojangAPI().getUUID(skin, true));
 
-            if (textures == null)
-                throw new SkinRequestException(Locale.ERROR_NO_SKIN);
+                if (textures == null)
+                    throw new SkinRequestException(Locale.ERROR_NO_SKIN);
 
-            setSkinData(skin, textures);
-        } catch (SkinRequestException e) {
-            if (!silent)
-                throw e;
-        } catch (Exception e) {
-            e.printStackTrace();
+                setSkinData(skin, textures);
+            } catch (SkinRequestException e) {
+                if (!silent)
+                    throw e;
+            } catch (Exception e) {
+                e.printStackTrace();
 
-            if (!silent)
-                throw new SkinRequestException(Locale.WAIT_A_MINUTE);
+                if (!silent)
+                    throw new SkinRequestException(Locale.WAIT_A_MINUTE);
+            }
         }
 
         return textures;
@@ -254,7 +256,7 @@ public class SkinStorage {
                     final String signature = crs.getString("Signature");
                     final String timestamp = crs.getString("timestamp");
 
-                    if (updateOutdated && isOld(Long.parseLong(timestamp))) {
+                    if (C.validMojangUsername(name) && updateOutdated && isOld(Long.parseLong(timestamp))) {
                         final Object skin = getMojangAPI().getSkinProperty(getMojangAPI().getUUID(name, true));
                         if (skin != null) {
                             setSkinData(name, skin);
@@ -300,7 +302,7 @@ public class SkinStorage {
                             }
                 }
 
-                if (updateOutdated && isOld(Long.parseLong(timestamp))) {
+                if (C.validMojangUsername(name) && updateOutdated && isOld(Long.parseLong(timestamp))) {
                     final Object skin = getMojangAPI().getSkinProperty(getMojangAPI().getUUID(name, true));
 
                     if (skin != null) {
@@ -714,7 +716,7 @@ public class SkinStorage {
             if (!Config.DEFAULT_SKINS_PREMIUM) {
                 // check if player is premium
                 try {
-                    if (getMojangAPI().getUUID(player, true) != null) {
+                    if (C.validMojangUsername(player) && getMojangAPI().getUUID(player, true) != null) {
                         // player is premium, return his skin name instead of default skin
                         return player;
                     }

--- a/src/main/java/net/skinsrestorer/shared/storage/SkinStorage.java
+++ b/src/main/java/net/skinsrestorer/shared/storage/SkinStorage.java
@@ -631,7 +631,7 @@ public class SkinStorage {
      */
     // skin update [include custom skin flag]
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    public boolean UpdateSkinData(String skin) throws SkinRequestException {
+    public boolean updateSkinData(String skin) throws SkinRequestException {
         if (!C.validUsername(skin))
             throw new SkinRequestException(Locale.ERROR_UPDATING_CUSTOMSKIN);
 

--- a/src/main/java/net/skinsrestorer/shared/storage/SkinStorage.java
+++ b/src/main/java/net/skinsrestorer/shared/storage/SkinStorage.java
@@ -632,7 +632,7 @@ public class SkinStorage {
     // skin update [include custom skin flag]
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean updateSkinData(String skin) throws SkinRequestException {
-        if (!C.validUsername(skin))
+        if (!C.validMojangUsername(skin))
             throw new SkinRequestException(Locale.ERROR_UPDATING_CUSTOMSKIN);
 
         // Check if updating is disabled for skin (by timestamp = 0)

--- a/src/main/java/net/skinsrestorer/shared/update/UpdateChecker.java
+++ b/src/main/java/net/skinsrestorer/shared/update/UpdateChecker.java
@@ -48,9 +48,12 @@ public class UpdateChecker {
     private final int resourceId;
     private final SRLogger log;
 
-    private final @Getter String currentVersion;
-    private final @Getter String userAgent;
-    private @Getter ResourceInfo latestResourceInfo;
+    private final @Getter
+    String currentVersion;
+    private final @Getter
+    String userAgent;
+    private @Getter
+    ResourceInfo latestResourceInfo;
 
     public UpdateChecker(int resourceId, String currentVersion, SRLogger log, String userAgent) {
         this.resourceId = resourceId;

--- a/src/main/java/net/skinsrestorer/shared/update/UpdateCheckerGitHub.java
+++ b/src/main/java/net/skinsrestorer/shared/update/UpdateCheckerGitHub.java
@@ -61,12 +61,12 @@ public class UpdateCheckerGitHub extends UpdateChecker {
             }
 
             JsonObject apiResponse = new JsonParser().parse(new InputStreamReader(connection.getInputStream())).getAsJsonObject();
-            this.releaseInfo = new Gson().fromJson(apiResponse, GitHubReleaseInfo.class);
+            releaseInfo = new Gson().fromJson(apiResponse, GitHubReleaseInfo.class);
 
             releaseInfo.assets.forEach(gitHubAssetInfo -> {
                 releaseInfo.latestDownloadURL = gitHubAssetInfo.browser_download_url;
 
-                if (this.isVersionNewer(this.currentVersion, releaseInfo.tag_name)) {
+                if (isVersionNewer(currentVersion, releaseInfo.tag_name)) {
                     callback.updateAvailable(releaseInfo.tag_name, gitHubAssetInfo.browser_download_url, true);
                 } else {
                     callback.upToDate();
@@ -81,6 +81,6 @@ public class UpdateCheckerGitHub extends UpdateChecker {
 
     @Override
     public GitHubReleaseInfo getLatestResourceInfo() {
-        return this.releaseInfo;
+        return releaseInfo;
     }
 }

--- a/src/main/java/net/skinsrestorer/shared/update/UpdateCheckerGitHub.java
+++ b/src/main/java/net/skinsrestorer/shared/update/UpdateCheckerGitHub.java
@@ -24,6 +24,7 @@ package net.skinsrestorer.shared.update;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.utils.SRLogger;
 import org.inventivetalent.update.spiget.UpdateCallback;
 
@@ -35,7 +36,6 @@ import java.util.logging.Level;
 public class UpdateCheckerGitHub extends UpdateChecker {
     private static final String RESOURCE_ID = "SkinsRestorerX";
     private static final String RELEASES_URL_LATEST = "https://api.github.com/repos/SkinsRestorer/%s/releases/latest";
-    private static final String RELEASES_URL = "https://api.github.com/repos/SkinsRestorer/%s/releases";
     private final SRLogger log;
     private final String userAgent;
     private final String currentVersion;
@@ -53,12 +53,6 @@ public class UpdateCheckerGitHub extends UpdateChecker {
         try {
             HttpURLConnection connection = (HttpURLConnection) new URL(String.format(RELEASES_URL_LATEST, RESOURCE_ID)).openConnection();
             connection.setRequestProperty("User-Agent", this.userAgent);
-            int responsecode = connection.getResponseCode();
-
-            if (responsecode != 200) {
-                log.logAlways(Level.WARNING, "Failed to get release info from api.github.com.");
-                return;
-            }
 
             JsonObject apiResponse = new JsonParser().parse(new InputStreamReader(connection.getInputStream())).getAsJsonObject();
             releaseInfo = new Gson().fromJson(apiResponse, GitHubReleaseInfo.class);
@@ -74,8 +68,9 @@ public class UpdateCheckerGitHub extends UpdateChecker {
             });
 
         } catch (Exception e) {
-            log.logAlways(Level.WARNING, "Failed to get release info from api.github.com.");
-            e.printStackTrace();
+            log.logAlways(Level.WARNING, "Failed to get release info from api.github.com. \n If this message is repeated a lot, please see http://skinsrestorer.net/firewall");
+            if (Config.DEBUG)
+                e.printStackTrace();
         }
     }
 

--- a/src/main/java/net/skinsrestorer/shared/utils/C.java
+++ b/src/main/java/net/skinsrestorer/shared/utils/C.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 public class C {
     private static final Pattern namePattern = Pattern.compile("^[a-zA-Z0-9_\\-]+$");
     private static final Pattern urlPattern = Pattern.compile("^https?://.*");
+
     private C() {
     }
 
@@ -55,7 +56,7 @@ public class C {
         return urlPattern.matcher(url).matches();
     }
 
-    public static boolean AllowedUrlIfEnabled(String url) {
+    public static boolean isAllowed(String url) {
         if (Config.RESTRICT_SKIN_URLS_ENABLED) {
             for (String possiblyAllowedUrl : Config.RESTRICT_SKIN_URLS_LIST) {
                 if (url.startsWith(possiblyAllowedUrl)) {

--- a/src/main/java/net/skinsrestorer/shared/utils/C.java
+++ b/src/main/java/net/skinsrestorer/shared/utils/C.java
@@ -58,7 +58,7 @@ public class C {
         return urlPattern.matcher(url).matches();
     }
 
-    public static boolean isAllowed(String url) {
+    public static boolean allowedSkinUrl(String url) {
         if (Config.RESTRICT_SKIN_URLS_ENABLED) {
             for (String possiblyAllowedUrl : Config.RESTRICT_SKIN_URLS_LIST) {
                 if (url.startsWith(possiblyAllowedUrl)) {

--- a/src/main/java/net/skinsrestorer/shared/utils/C.java
+++ b/src/main/java/net/skinsrestorer/shared/utils/C.java
@@ -46,7 +46,7 @@ public class C {
         return new String(b);
     }
 
-    public static boolean validUsername(String username) {
+    public static boolean validMojangUsername(String username) {
         //Note: there are exceptions of players with under 3 characters, who bought the game early in its development.
         if (username.length() > 16)
             return false;

--- a/src/main/java/net/skinsrestorer/shared/utils/C.java
+++ b/src/main/java/net/skinsrestorer/shared/utils/C.java
@@ -46,6 +46,7 @@ public class C {
     }
 
     public static boolean validUsername(String username) {
+        //Note: there are exceptions of players with under 3 characters, who bought the game early in its development.
         if (username.length() > 16)
             return false;
 

--- a/src/main/java/net/skinsrestorer/shared/utils/C.java
+++ b/src/main/java/net/skinsrestorer/shared/utils/C.java
@@ -26,6 +26,7 @@ import net.skinsrestorer.shared.storage.Config;
 import java.util.regex.Pattern;
 
 public class C {
+    //Note: Players who bought the game early in its development can have "-" in usernames.
     private static final Pattern namePattern = Pattern.compile("^[a-zA-Z0-9_\\-]+$");
     private static final Pattern urlPattern = Pattern.compile("^https?://.*");
 

--- a/src/main/java/net/skinsrestorer/shared/utils/MojangAPI.java
+++ b/src/main/java/net/skinsrestorer/shared/utils/MojangAPI.java
@@ -44,9 +44,10 @@ public class MojangAPI {
     private static final String SKIN_URL = "https://api.minetools.eu/profile/%uuid%";
     private static final String SKIN_URL_MOJANG = "https://sessionserver.mojang.com/session/minecraft/profile/%uuid%?unsigned=false";
     private static final String SKIN_URL_BACKUP = "https://api.ashcon.app/mojang/v2/user/%uuid%";
-
-    private @Getter @Setter SkinStorage skinStorage;
     private final SRLogger logger;
+    private @Getter
+    @Setter
+    SkinStorage skinStorage;
 
     public MojangAPI(SRLogger logger) {
         this.logger = logger;
@@ -80,7 +81,7 @@ public class MojangAPI {
                 }
 
                 if (property.valuesFromJson(raw)) {
-                    return this.getSkinStorage().createProperty("textures", property.getValue(), property.getSignature());
+                    return getSkinStorage().createProperty("textures", property.getValue(), property.getSignature());
                 }
             }
 
@@ -98,7 +99,7 @@ public class MojangAPI {
 
     public Object getSkinPropertyMojang(String uuid, boolean tryNext) {
         if (tryNext)
-        logger.log("Trying Mojang API to get skin property for " + uuid + ".");
+            logger.log("Trying Mojang API to get skin property for " + uuid + ".");
 
         String output;
         try {
@@ -108,7 +109,7 @@ public class MojangAPI {
             Property property = new Property();
 
             if (obj.has("properties") && property.valuesFromJson(obj)) {
-                return this.getSkinStorage().createProperty("textures", property.getValue(), property.getSignature());
+                return getSkinStorage().createProperty("textures", property.getValue(), property.getSignature());
             }
 
         } catch (Exception e) {
@@ -125,7 +126,7 @@ public class MojangAPI {
 
     public Object getSkinPropertyBackup(String uuid, boolean tryNext) {
         if (tryNext)
-        logger.log("Trying backup API to get skin property for " + uuid + ".");
+            logger.log("Trying backup API to get skin property for " + uuid + ".");
 
         try {
             String output = readURL(SKIN_URL_BACKUP.replace("%uuid%", uuid), 10000);
@@ -181,7 +182,7 @@ public class MojangAPI {
 
     public String getUUIDMojang(String name, boolean tryNext) throws SkinRequestException {
         if (tryNext)
-        logger.log("Trying Mojang API to get UUID for player " + name + ".");
+            logger.log("Trying Mojang API to get UUID for player " + name + ".");
 
         String output;
         try {
@@ -214,7 +215,7 @@ public class MojangAPI {
 
     public String getUUIDBackup(String name, boolean tryNext) throws SkinRequestException {
         if (tryNext)
-        logger.log("Trying backup API to get UUID for player " + name + ".");
+            logger.log("Trying backup API to get UUID for player " + name + ".");
 
         try {
             String output = readURL(UUID_URL_BACKUP.replace("%name%", name), 10000);

--- a/src/main/java/net/skinsrestorer/shared/utils/ServiceChecker.java
+++ b/src/main/java/net/skinsrestorer/shared/utils/ServiceChecker.java
@@ -30,8 +30,11 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class ServiceChecker {
-    private @Setter @Getter ServiceCheckResponse response;
-    private @Setter MojangAPI mojangAPI;
+    private @Setter
+    @Getter
+    ServiceCheckResponse response;
+    private @Setter
+    MojangAPI mojangAPI;
 
     public ServiceChecker() {
         this.response = new ServiceCheckResponse();
@@ -97,7 +100,8 @@ public class ServiceChecker {
     }
 
     public static class ServiceCheckResponse {
-        private final @Getter List<String> results = new LinkedList<>();
+        private final @Getter
+        List<String> results = new LinkedList<>();
         private final AtomicInteger workingUUID = new AtomicInteger();
         private final AtomicInteger workingProfile = new AtomicInteger();
 

--- a/src/main/java/net/skinsrestorer/shared/utils/SharedMethods.java
+++ b/src/main/java/net/skinsrestorer/shared/utils/SharedMethods.java
@@ -8,12 +8,12 @@
  * it under the terms of the GNU General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.

--- a/src/main/java/net/skinsrestorer/sponge/SkinsRestorer.java
+++ b/src/main/java/net/skinsrestorer/sponge/SkinsRestorer.java
@@ -63,27 +63,27 @@ import java.util.logging.Level;
 
 @Plugin(id = "skinsrestorer", name = PluginData.NAME, version = PluginData.VERSION, url = PluginData.URL, authors = {"Blackfire62", "McLive"})
 public class SkinsRestorer implements SRPlugin {
-    private static @Getter
-    SkinsRestorer instance;
+    @Getter
+    private static SkinsRestorer instance;
     private final Metrics metrics;
+    @Getter
+    private final boolean bungeeEnabled = false;
     @Inject
     protected Game game;
-    private @Getter
-    String configPath;
-    private @Getter
-    SkinApplierSponge skinApplierSponge;
-    private @Getter
-    SRLogger srLogger;
-    private @Getter final
-    boolean bungeeEnabled = false;
-    private @Getter
-    SkinStorage skinStorage;
-    private @Getter
-    MojangAPI mojangAPI;
-    private @Getter
-    MineSkinAPI mineSkinAPI;
-    private @Getter
-    SkinsRestorerAPI skinsRestorerSpongeAPI;
+    @Getter
+    private String configPath;
+    @Getter
+    private SkinApplierSponge skinApplierSponge;
+    @Getter
+    private SRLogger srLogger;
+    @Getter
+    private SkinStorage skinStorage;
+    @Getter
+    private MojangAPI mojangAPI;
+    @Getter
+    private MineSkinAPI mineSkinAPI;
+    @Getter
+    private SkinsRestorerAPI skinsRestorerSpongeAPI;
     private UpdateChecker updateChecker;
     private CommandSource console;
     @Inject
@@ -106,50 +106,50 @@ public class SkinsRestorer implements SRPlugin {
         instance = this;
         console = Sponge.getServer().getConsole();
         configPath = Sponge.getGame().getConfigManager().getPluginConfig(this).getDirectory().toString();
-        this.srLogger = new SRLogger(new File(configPath));
-        File UPDATER_DISABLED = new File(this.configPath, "noupdate.txt");
+        srLogger = new SRLogger(new File(configPath));
+        File updaterDisabled = new File(configPath, "noupdate.txt");
 
         // Check for updates
-        if (!UPDATER_DISABLED.exists()) {
-            this.updateChecker = new UpdateCheckerGitHub(2124, this.getVersion(), this.srLogger, "SkinsRestorerUpdater/Sponge");
-            this.checkUpdate(bungeeEnabled);
+        if (!updaterDisabled.exists()) {
+            updateChecker = new UpdateCheckerGitHub(2124, getVersion(), srLogger, "SkinsRestorerUpdater/Sponge");
+            checkUpdate(bungeeEnabled);
 
             Sponge.getScheduler().createTaskBuilder().execute(() -> {
-                this.checkUpdate(bungeeEnabled, false);
+                checkUpdate(bungeeEnabled, false);
             }).interval(10, TimeUnit.MINUTES).delay(10, TimeUnit.MINUTES);
         } else {
             srLogger.logAlways(Level.INFO, "Updater Disabled");
         }
-
-        this.skinStorage = new SkinStorage(SkinStorage.Platform.SPONGE);
+        
+        skinStorage = new SkinStorage(SkinStorage.Platform.SPONGE);
 
         // Init config files
         Config.load(configPath, getClass().getClassLoader().getResourceAsStream("config.yml"));
         Locale.load(configPath);
 
-        this.mojangAPI = new MojangAPI(this.srLogger);
-        this.mineSkinAPI = new MineSkinAPI(this.srLogger);
+        mojangAPI = new MojangAPI(srLogger);
+        mineSkinAPI = new MineSkinAPI(srLogger);
 
-        this.skinStorage.setMojangAPI(mojangAPI);
+        skinStorage.setMojangAPI(mojangAPI);
         // Init storage
-        if (!this.initStorage())
+        if (!initStorage())
             return;
 
-        this.mojangAPI.setSkinStorage(this.skinStorage);
-        this.mineSkinAPI.setSkinStorage(this.skinStorage);
+        mojangAPI.setSkinStorage(skinStorage);
+        mineSkinAPI.setSkinStorage(skinStorage);
 
         // Init commands
-        this.initCommands();
+        initCommands();
 
         // Init SkinApplier
-        this.skinApplierSponge = new SkinApplierSponge(this);
+        skinApplierSponge = new SkinApplierSponge(this);
 
         // Init API
-        this.skinsRestorerSpongeAPI = new SkinsRestorerAPI(this.mojangAPI, this.skinStorage, this);
+        skinsRestorerSpongeAPI = new SkinsRestorerAPI(mojangAPI, skinStorage, this);
 
         // Run connection check
         ServiceChecker checker = new ServiceChecker();
-        checker.setMojangAPI(this.mojangAPI);
+        checker.setMojangAPI(mojangAPI);
         checker.checkServices();
         ServiceChecker.ServiceCheckResponse response = checker.getResponse();
 
@@ -209,22 +209,22 @@ public class SkinsRestorer implements SRPlugin {
                 mysql.openConnection();
                 mysql.createTable();
 
-                this.skinStorage.setMysql(mysql);
+                skinStorage.setMysql(mysql);
             } catch (Exception e) {
                 System.out.println("§e[§2SkinsRestorer§e] §cCan't connect to MySQL! Disabling SkinsRestorer.");
                 return false;
             }
         } else {
-            this.skinStorage.loadFolders(new File(configPath));
+            skinStorage.loadFolders(new File(configPath));
         }
 
         // Preload default skins
-        Sponge.getScheduler().createAsyncExecutor(this).execute(this.skinStorage::preloadDefaultSkins);
+        Sponge.getScheduler().createAsyncExecutor(this).execute(skinStorage::preloadDefaultSkins);
         return true;
     }
 
     private void checkUpdate(boolean bungeeMode) {
-        this.checkUpdate(bungeeMode, true);
+        checkUpdate(bungeeMode, true);
     }
 
     private void checkUpdate(boolean bungeeMode, boolean showUpToDate) {

--- a/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
@@ -251,6 +251,7 @@ public class SkinCommand extends BaseCommand {
                 if (save)
                     plugin.getSkinStorage().setPlayerSkin(pName, skin);
                 plugin.getSkinApplierSponge().applySkin(new PlayerWrapper(p), plugin.getSkinsRestorerSpongeAPI());
+                if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
                 p.sendMessage(plugin.parseMessage(Locale.SKIN_CHANGE_SUCCESS));
                 return true;
             } catch (SkinRequestException e) {
@@ -287,6 +288,7 @@ public class SkinCommand extends BaseCommand {
                 plugin.getSkinStorage().setPlayerSkin(pName, skinentry); // set player to "whitespaced" name then reload skin
                 plugin.getSkinApplierSponge().applySkin(new PlayerWrapper(p), plugin.getSkinsRestorerSpongeAPI());
 
+                if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
                 p.sendMessage(plugin.parseMessage(Locale.SKIN_CHANGE_SUCCESS));
 
                 return true;

--- a/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
@@ -55,7 +55,7 @@ public class SkinCommand extends BaseCommand {
     @Default
     @SuppressWarnings({"deprecation"})
     public void onDefault(CommandSource source) {
-        this.onHelp(source, this.getCurrentCommandManager().generateCommandHelp());
+        onHelp(source, getCurrentCommandManager().generateCommandHelp());
     }
 
     @Default
@@ -64,7 +64,7 @@ public class SkinCommand extends BaseCommand {
     @Syntax("%SyntaxDefaultCommand")
     @SuppressWarnings({"unused"})
     public void onSkinSetShort(Player p, @Single String skin) {
-        this.onSkinSetOther(p, new OnlinePlayer(p), skin);
+        onSkinSetOther(p, new OnlinePlayer(p), skin);
     }
 
     @HelpCommand
@@ -81,7 +81,7 @@ public class SkinCommand extends BaseCommand {
     @Description("%helpSkinClear")
     @SuppressWarnings({"unused"})
     public void onSkinClear(Player p) {
-        this.onSkinClearOther(p, new OnlinePlayer(p));
+        onSkinClearOther(p, new OnlinePlayer(p));
     }
 
     @Subcommand("clear")
@@ -269,7 +269,7 @@ public class SkinCommand extends BaseCommand {
                 return false;
             }
 
-            if (!C.AllowedUrlIfEnabled(skin)) {
+            if (!C.isAllowed(skin)) {
                 source.sendMessage(plugin.parseMessage(Locale.SKINURL_DISALLOWED));
                 CooldownStorage.resetCooldown(senderName);
                 return false;

--- a/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
@@ -248,7 +248,9 @@ public class SkinCommand extends BaseCommand {
         final String oldSkinName = plugin.getSkinStorage().getPlayerSkin(pName);
 
         if (C.validUrl(skin)) {
-            if (!source.hasPermission("skinsrestorer.command.set.url") && !Config.SKINWITHOUTPERM) {
+            if (!source.hasPermission("skinsrestorer.command.set.url")
+                    && !Config.SKINWITHOUTPERM
+                    && !clear) { //ignore /skin clear when DefaultSkin = url
                 source.sendMessage(plugin.parseMessage(Locale.PLAYER_HAS_NO_PERMISSION_URL));
                 CooldownStorage.resetCooldown(senderName);
                 return false;
@@ -271,10 +273,8 @@ public class SkinCommand extends BaseCommand {
                         Long.toString(System.currentTimeMillis() + (100L * 365 * 24 * 60 * 60 * 1000))); // "generate" and save skin for 100 years
                 plugin.getSkinStorage().setPlayerSkin(pName, skinentry); // set player to "whitespaced" name then reload skin
                 plugin.getSkinApplierSponge().applySkin(new PlayerWrapper(p), plugin.getSkinsRestorerSpongeAPI());
-
                 if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
                     p.sendMessage(plugin.parseMessage(Locale.SKIN_CHANGE_SUCCESS));
-
                 return true;
             } catch (SkinRequestException e) {
                 source.sendMessage(plugin.parseMessage(e.getMessage()));
@@ -293,10 +293,11 @@ public class SkinCommand extends BaseCommand {
             } catch (SkinRequestException e) {
                 source.sendMessage(plugin.parseMessage(e.getMessage()));
                 // set custom skin name back to old one if there is an exception
-                rollback(p, oldSkinName, save);
             }
         }
+        // Set CoolDown to ERROR_COOLDOWN and rollback to old skin on exception
         CooldownStorage.setCooldown(senderName, Config.SKIN_ERROR_COOLDOWN, TimeUnit.SECONDS);
+        rollback(p, oldSkinName, save);
         return false;
     }
 

--- a/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
@@ -265,11 +265,13 @@ public class SkinCommand extends BaseCommand {
         if (C.validUrl(skin)) {
             if (!source.hasPermission("skinsrestorer.command.set.url") && !Config.SKINWITHOUTPERM) {
                 source.sendMessage(plugin.parseMessage(Locale.PLAYER_HAS_NO_PERMISSION_URL));
+                CooldownStorage.resetCooldown(senderName);
                 return false;
             }
 
             if (!C.AllowedUrlIfEnabled(skin)) {
                 source.sendMessage(plugin.parseMessage(Locale.SKINURL_DISALLOWED));
+                CooldownStorage.resetCooldown(senderName);
                 return false;
             }
 

--- a/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
@@ -222,7 +222,7 @@ public class SkinCommand extends BaseCommand {
     // if save is false, we won't save the skin skin name
     // because default skin names shouldn't be saved as the users custom skin
     private boolean setSkin(CommandSource source, Player p, String skin, boolean save, boolean clear) {
-        if (skin.equalsIgnoreCase("null") || !C.validUsername(skin) && !C.validUrl(skin)) {
+        if (skin.equalsIgnoreCase("null") || !C.validMojangUsername(skin) && !C.validUrl(skin)) {
             source.sendMessage(plugin.parseMessage(Locale.INVALID_PLAYER.replace("%player", skin)));
             return false;
         }
@@ -246,7 +246,7 @@ public class SkinCommand extends BaseCommand {
 
         final String pName = p.getName();
         final String oldSkinName = plugin.getSkinStorage().getPlayerSkin(pName);
-        if (C.validUsername(skin)) {
+        if (C.validMojangUsername(skin)) {
             try {
                 if (save)
                     plugin.getSkinStorage().setPlayerSkin(pName, skin);

--- a/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
@@ -270,7 +270,7 @@ public class SkinCommand extends BaseCommand {
                 return false;
             }
 
-            if (!C.isAllowed(skin)) {
+            if (!C.allowedSkinUrl(skin)) {
                 source.sendMessage(plugin.parseMessage(Locale.SKINURL_DISALLOWED));
                 CooldownStorage.resetCooldown(senderName);
                 return false;

--- a/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
@@ -144,7 +144,7 @@ public class SkinCommand extends BaseCommand {
                         return;
                     }
 
-                    if (!plugin.getSkinStorage().forceUpdateSkinData(skin)) {
+                    if (!plugin.getSkinStorage().UpdateSkinData(skin)) {
                         source.sendMessage(plugin.parseMessage(Locale.ERROR_UPDATING_SKIN));
                         return;
                     }

--- a/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
@@ -144,7 +144,7 @@ public class SkinCommand extends BaseCommand {
                         return;
                     }
 
-                    if (!plugin.getSkinStorage().UpdateSkinData(skin)) {
+                    if (!plugin.getSkinStorage().updateSkinData(skin)) {
                         source.sendMessage(plugin.parseMessage(Locale.ERROR_UPDATING_SKIN));
                         return;
                     }

--- a/src/main/java/net/skinsrestorer/sponge/listeners/LoginListener.java
+++ b/src/main/java/net/skinsrestorer/sponge/listeners/LoginListener.java
@@ -41,13 +41,13 @@ public class LoginListener implements EventListener<ClientConnectionEvent.Auth> 
 
     @Override
     public void handle(Auth e) {
-        if (e.isCancelled())
+        if (e.isCancelled() && Config.NO_SKIN_IF_LOGIN_CANCELED)
             return;
 
         if (Config.DISABLE_ONJOIN_SKINS)
             return;
 
-        GameProfile profile = e.getProfile();
+        final GameProfile profile = e.getProfile();
 
         profile.getName().ifPresent(name -> {
             try {

--- a/src/main/java/net/skinsrestorer/sponge/utils/SkinApplierSponge.java
+++ b/src/main/java/net/skinsrestorer/sponge/utils/SkinApplierSponge.java
@@ -49,7 +49,7 @@ public class SkinApplierSponge implements SRApplier {
     }
 
     public void applySkin(final PlayerWrapper player, final SkinsRestorerAPI api) throws SkinRequestException {
-        this.applySkin(player, api.getSkinName(player.get(Player.class).getName()), true);
+        applySkin(player, api.getSkinName(player.get(Player.class).getName()), true);
     }
 
     public void updateProfileSkin(GameProfile profile, String skin) throws SkinRequestException {

--- a/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
@@ -147,7 +147,7 @@ public class SkinCommand extends BaseCommand {
                         return;
                     }
 
-                    if (!plugin.getSkinStorage().forceUpdateSkinData(skin)) {
+                    if (!plugin.getSkinStorage().UpdateSkinData(skin)) {
                         source.sendMessage(plugin.deserialize(Locale.ERROR_UPDATING_SKIN));
                         return;
                     }

--- a/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
@@ -270,11 +270,13 @@ public class SkinCommand extends BaseCommand {
         if (C.validUrl(skin)) {
             if (!source.hasPermission("skinsrestorer.command.set.url") && !Config.SKINWITHOUTPERM) {
                 source.sendMessage(plugin.deserialize(Locale.PLAYER_HAS_NO_PERMISSION_URL));
+                CooldownStorage.resetCooldown(getSenderName(source));
                 return false;
             }
 
             if (!C.AllowedUrlIfEnabled(skin)) {
                 source.sendMessage(plugin.deserialize(Locale.SKINURL_DISALLOWED));
+                CooldownStorage.resetCooldown(getSenderName(source));
                 return false;
             }
 

--- a/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
@@ -275,7 +275,7 @@ public class SkinCommand extends BaseCommand {
                 return false;
             }
 
-            if (!C.isAllowed(skin)) {
+            if (!C.allowedSkinUrl(skin)) {
                 source.sendMessage(plugin.deserialize(Locale.SKINURL_DISALLOWED));
                 CooldownStorage.resetCooldown(getSenderName(source));
                 return false;

--- a/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
@@ -256,6 +256,7 @@ public class SkinCommand extends BaseCommand {
                 if (save)
                     plugin.getSkinStorage().setPlayerSkin(pName, skin);
                 plugin.getSkinApplierVelocity().applySkin(new PlayerWrapper(p), plugin.getSkinsRestorerVelocityAPI());
+                if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
                 p.sendMessage(plugin.deserialize(Locale.SKIN_CHANGE_SUCCESS));
             } catch (SkinRequestException e) {
                 source.sendMessage(plugin.deserialize(e.getMessage()));
@@ -289,6 +290,7 @@ public class SkinCommand extends BaseCommand {
                         Long.toString(System.currentTimeMillis() + (100L * 365 * 24 * 60 * 60 * 1000))); // "generate" and save skin for 100 years
                 plugin.getSkinStorage().setPlayerSkin(pName, skinentry); // set player to "whitespaced" name then reload skin
                 plugin.getSkinApplierVelocity().applySkin(new PlayerWrapper(p), plugin.getSkinsRestorerVelocityAPI());
+                if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
                 p.sendMessage(plugin.deserialize(Locale.SKIN_CHANGE_SUCCESS));
             } catch (SkinRequestException e) {
                 source.sendMessage(plugin.deserialize(e.getMessage()));

--- a/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
@@ -147,7 +147,7 @@ public class SkinCommand extends BaseCommand {
                         return;
                     }
 
-                    if (!plugin.getSkinStorage().UpdateSkinData(skin)) {
+                    if (!plugin.getSkinStorage().updateSkinData(skin)) {
                         source.sendMessage(plugin.deserialize(Locale.ERROR_UPDATING_SKIN));
                         return;
                     }

--- a/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
@@ -51,13 +51,13 @@ public class SkinCommand extends BaseCommand {
 
     public SkinCommand(SkinsRestorer plugin) {
         this.plugin = plugin;
-        log = plugin.getLogger();
+        log = plugin.getSrLogger();
     }
 
     @Default
     @SuppressWarnings({"deprecation"})
     public void onDefault(CommandSource source) {
-        this.onHelp(source, this.getCurrentCommandManager().generateCommandHelp());
+        onHelp(source, getCurrentCommandManager().generateCommandHelp());
     }
 
     @Default
@@ -66,7 +66,7 @@ public class SkinCommand extends BaseCommand {
     @Syntax("%SyntaxDefaultCommand")
     @SuppressWarnings({"unused"})
     public void onSkinSetShort(Player p, @Single String skin) {
-        this.onSkinSetOther(p, new OnlinePlayer(p), skin);
+        onSkinSetOther(p, new OnlinePlayer(p), skin);
     }
 
     @HelpCommand
@@ -84,7 +84,7 @@ public class SkinCommand extends BaseCommand {
     @Description("%helpSkinClear")
     @SuppressWarnings({"unused"})
     public void onSkinClear(Player p) {
-        this.onSkinClearOther(p, new OnlinePlayer(p));
+        onSkinClearOther(p, new OnlinePlayer(p));
     }
 
     @Subcommand("clear")
@@ -106,7 +106,7 @@ public class SkinCommand extends BaseCommand {
             // remove users defined skin from database
             plugin.getSkinStorage().removePlayerSkin(pName);
 
-            if (this.setSkin(source, p, skin, false, true)) {
+            if (setSkin(source, p, skin, false, true)) {
                 if (source == p)
                     source.sendMessage(plugin.deserialize(Locale.SKIN_CLEAR_SUCCESS));
                 else
@@ -121,7 +121,7 @@ public class SkinCommand extends BaseCommand {
     @Description("%helpSkinUpdate")
     @SuppressWarnings({"unused"})
     public void onSkinUpdate(Player p) {
-        this.onSkinUpdateOther(p, new OnlinePlayer(p));
+        onSkinUpdateOther(p, new OnlinePlayer(p));
     }
 
     @Subcommand("update")
@@ -161,7 +161,7 @@ public class SkinCommand extends BaseCommand {
                 return;
             }
 
-            if (this.setSkin(source, p, skin, false, false)) {
+            if (setSkin(source, p, skin, false, false)) {
                 if (source == p)
                     source.sendMessage(plugin.deserialize(Locale.SUCCESS_UPDATING_SKIN));
                 else
@@ -176,7 +176,7 @@ public class SkinCommand extends BaseCommand {
     @Syntax("%SyntaxSkinSet")
     public void onSkinSet(Player p, String[] skin) {
         if (skin.length > 0) {
-            this.onSkinSetOther(p, new OnlinePlayer(p), skin[0]);
+            onSkinSetOther(p, new OnlinePlayer(p), skin[0]);
         } else {
             throw new InvalidCommandArgument(MessageKeys.INVALID_SYNTAX);
         }
@@ -197,7 +197,7 @@ public class SkinCommand extends BaseCommand {
                 }
             }
 
-            if (this.setSkin(source, p, skin) && !(source == p)) {
+            if (setSkin(source, p, skin) && !(source == p)) {
                 source.sendMessage(LegacyComponentSerializer.legacy().deserialize(Locale.ADMIN_SET_SKIN.replace("%player", p.getUsername())));
             }
         });
@@ -211,7 +211,7 @@ public class SkinCommand extends BaseCommand {
     public void onSkinSetUrl(Player p, String[] url) {
         if (url.length > 0) {
             if (C.validUrl(url[0])) {
-                this.onSkinSetOther(p, new OnlinePlayer(p), url[0]);
+                onSkinSetOther(p, new OnlinePlayer(p), url[0]);
             } else {
                 p.sendMessage(LegacyComponentSerializer.legacy().deserialize(Locale.ERROR_INVALID_URLSKIN));
             }
@@ -221,7 +221,7 @@ public class SkinCommand extends BaseCommand {
     }
 
     private boolean setSkin(CommandSource source, Player p, String skin) {
-        return this.setSkin(source, p, skin, true, false);
+        return setSkin(source, p, skin, true, false);
     }
 
     // if save is false, we won't save the skin skin name
@@ -260,11 +260,11 @@ public class SkinCommand extends BaseCommand {
             } catch (SkinRequestException e) {
                 source.sendMessage(plugin.deserialize(e.getMessage()));
                 // set custom skin name back to old one if there is an exception
-                this.rollback(p, oldSkinName, save);
+                rollback(p, oldSkinName, save);
             } catch (Exception e) {
                 e.printStackTrace();
                 // set custom skin name back to old one if there is an exception
-                this.rollback(p, oldSkinName, save);
+                rollback(p, oldSkinName, save);
             }
         }
         if (C.validUrl(skin)) {
@@ -274,7 +274,7 @@ public class SkinCommand extends BaseCommand {
                 return false;
             }
 
-            if (!C.AllowedUrlIfEnabled(skin)) {
+            if (!C.isAllowed(skin)) {
                 source.sendMessage(plugin.deserialize(Locale.SKINURL_DISALLOWED));
                 CooldownStorage.resetCooldown(getSenderName(source));
                 return false;
@@ -293,11 +293,11 @@ public class SkinCommand extends BaseCommand {
             } catch (SkinRequestException e) {
                 source.sendMessage(plugin.deserialize(e.getMessage()));
                 // set custom skin name back to old one if there is an exception
-                this.rollback(p, oldSkinName, save);
+                rollback(p, oldSkinName, save);
             } catch (Exception e) {
                 e.printStackTrace();
                 // set custom skin name back to old one if there is an exception
-                this.rollback(p, oldSkinName, save);
+                rollback(p, oldSkinName, save);
             }
         }
         return true;

--- a/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
+++ b/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
@@ -227,7 +227,7 @@ public class SkinCommand extends BaseCommand {
     // if save is false, we won't save the skin skin name
     // because default skin names shouldn't be saved as the users custom skin
     private boolean setSkin(CommandSource source, Player p, String skin, boolean save, boolean clear) {
-        if (skin.equalsIgnoreCase("null") || !C.validUsername(skin) && !C.validUrl(skin)) {
+        if (skin.equalsIgnoreCase("null") || !C.validMojangUsername(skin) && !C.validUrl(skin)) {
             source.sendMessage(plugin.deserialize(Locale.INVALID_PLAYER.replace("%player", skin)));
             return false;
         }
@@ -250,7 +250,7 @@ public class SkinCommand extends BaseCommand {
 
         final String pName = p.getUsername();
         final String oldSkinName = plugin.getSkinStorage().getPlayerSkin(pName);
-        if (C.validUsername(skin)) {
+        if (C.validMojangUsername(skin)) {
             try {
                 plugin.getSkinStorage().getOrCreateSkinForPlayer(skin, false);
                 if (save)

--- a/src/main/java/net/skinsrestorer/velocity/listener/GameProfileRequest.java
+++ b/src/main/java/net/skinsrestorer/velocity/listener/GameProfileRequest.java
@@ -36,7 +36,7 @@ public class GameProfileRequest {
     @Inject
     public GameProfileRequest(SkinsRestorer plugin) {
         this.plugin = plugin;
-        log = plugin.getLogger();
+        log = plugin.getSrLogger();
     }
 
     @Subscribe

--- a/src/main/java/net/skinsrestorer/velocity/listener/GameProfileRequest.java
+++ b/src/main/java/net/skinsrestorer/velocity/listener/GameProfileRequest.java
@@ -39,17 +39,17 @@ public class GameProfileRequest {
         log = plugin.getSrLogger();
     }
 
+    //todo make async, add getOrCreateSkinForPlayer, make join same on all implementations
     @Subscribe
     public void onGameProfileRequest(GameProfileRequestEvent e) {
-        String name = e.getUsername();
-
         if (Config.DISABLE_ONJOIN_SKINS)
             return;
 
         if (e.isOnlineMode())
             return;
 
-        String skin = plugin.getSkinStorage().getDefaultSkinNameIfEnabled(name);
+        final String name = e.getUsername();
+        final String skin = plugin.getSkinStorage().getDefaultSkinNameIfEnabled(name);
 
         //todo: default skinurl support
         try {

--- a/src/main/java/net/skinsrestorer/velocity/utils/SkinApplierVelocity.java
+++ b/src/main/java/net/skinsrestorer/velocity/utils/SkinApplierVelocity.java
@@ -44,7 +44,7 @@ public class SkinApplierVelocity implements SRApplier {
 
     public SkinApplierVelocity(SkinsRestorer plugin) {
         this.plugin = plugin;
-        this.log = plugin.getLogger();
+        log = plugin.getSrLogger();
     }
 
     public void applySkin(PlayerWrapper player, SkinsRestorerAPI api) throws SkinRequestException {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,6 @@
 #################################
 #    SkinsRestorer Config.yml   #
-#      Generated on 14.0.0      #
+#  Generated on 14.1.0-snapshot #
 #################################
 #
 # We from SRTeam thank you for using our plugin!

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ description: ${project.description}
 website: https://skinsrestorer.net/
 authors: [Th3Tr0LLeR, McLive, DoNotSpamPls, knat]
 softdepend: ["ViaBackwards"]
-api-version: 1.16.5
+api-version: 1.13
 commands:
   skin:
     description: Main command.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ description: ${project.description}
 website: https://skinsrestorer.net/
 authors: [Th3Tr0LLeR, McLive, DoNotSpamPls, knat]
 softdepend: ["ViaBackwards"]
-api-version: 1.13
+api-version: 1.16.5
 commands:
   skin:
     description: Main command.
@@ -20,6 +20,9 @@ permissions:
      default: op   
    skinsrestorer.command.set:
      description: Allows access to change your skin.
+     default: op
+   skinsrestorer.command.set.url:
+     description: Allows access to change your skin by url.
      default: op
    skinsrestorer.command.clear:
      description: Allows access to clear your skin.
@@ -48,6 +51,12 @@ permissions:
      default: op
    skinsrestorer.admincommand.props:
      description: Allows access to get the skinprops of a player.
+     default: op
+   skinsrestorer.admincommand.applyskin:
+     description: Allows access to re-apply the skin of a player.
+     default: op
+   skinsrestorer.admincommand.createcustom:
+     description: Allows access to create a custom skin by url.
      default: op
 
    skinsrestorer.bypasscooldown:


### PR DESCRIPTION
This feature should improve name checking by not requesting skins that are not Mojang valid usernames but also give the ability's to set custom skin names that do not follow these guidelines

= test objectives =
[ ] skin clear on floodgate