### PR TITLE
Change config path on velocity

### DIFF
--- a/src/main/java/net/skinsrestorer/velocity/SkinsRestorer.java
+++ b/src/main/java/net/skinsrestorer/velocity/SkinsRestorer.java
@@ -67,7 +67,7 @@ import java.util.logging.Logger;
 @Plugin(id = "skinsrestorer", name = PluginData.NAME, version = PluginData.VERSION, description = PluginData.DESCRIPTION, url = PluginData.URL, authors = {"Blackfire62", "McLive"})
 public class SkinsRestorer implements SRPlugin {
     @Getter
-    private static final String CONFIG_PATH = "plugins" + File.separator + "SkinsRestorer" + File.separator + "";
+    private static final String CONFIG_PATH = "plugins" + File.separator + "skinsrestorer" + File.separator + "";
     @Getter
     private static SkinsRestorer instance;
     @Getter


### PR DESCRIPTION
Changed `CONFIG_PATH` on velocity plugin from having `SkinsRestorer` to having `skinsrestorer`. 

This is necessary because:

Velocity automatically creates the plugin's data folder having the *same name* as the plugin's id. The plugin's ID is `skinsrestorer`. Here, config path is set with `SkinsRestorer`. This would point to **two seperate directories** on case-sensitive file systems!

This is not good, as this breaks some backup software, since the backup software considers them as duplicate, and doesn't transfer all the files. Merging the directories will break the plugin.

Hence, The `CONFIG_PATH` on velocity should be changed to match the dataFolder's path that velocity creates.