### PR TITLE
Fix previous gamemode in F3+F4 gamemode switcher

### DIFF
--- a/src/main/java/net/skinsrestorer/bukkit/skinapplier/SpigotSkinRefresher.java
+++ b/src/main/java/net/skinsrestorer/bukkit/skinapplier/SpigotSkinRefresher.java
@@ -165,7 +165,9 @@ public class SpigotSkinRefresher implements Consumer<Player> {
                             Object dimensionKey = ReflectionUtil.invokeMethod(worldObject, "getDimensionKey");
                             boolean debug = (boolean) ReflectionUtil.invokeMethod(worldObject, "isDebugWorld");
                             boolean flat = (boolean) ReflectionUtil.invokeMethod(worldObject, "isFlatWorld");
-                            Enum<?> enumGamemodePrevious = (Enum<?>) ReflectionUtil.invokeMethod(playerIntManager, "c");
+                            List<Object> gameModeList = ReflectionUtil.getFieldByTypeList(playerIntManager, "EnumGamemode");
+
+                            Enum<?> enumGamemodePrevious = (Enum<?>) getFromListExcluded(gameModeList, enumGamemode);
 
                             // Minecraft 1.16.1 changes
                             try {
@@ -242,5 +244,14 @@ public class SpigotSkinRefresher implements Consumer<Player> {
         } catch (ReflectionException e) {
             e.printStackTrace();
         }
+    }
+
+    private Object getFromListExcluded(List<Object> list, Object... excluded) {
+        for (Object obj : list) {
+            if (obj != excluded)
+                return obj;
+        }
+
+        return null;
     }
 }

--- a/src/main/java/net/skinsrestorer/bukkit/skinapplier/SpigotSkinRefresher.java
+++ b/src/main/java/net/skinsrestorer/bukkit/skinapplier/SpigotSkinRefresher.java
@@ -134,6 +134,13 @@ public class SpigotSkinRefresher implements Consumer<Player> {
 
             Object playerIntManager = ReflectionUtil.getFieldByType(craftHandle, "PlayerInteractManager");
             Enum<?> enumGamemode = (Enum<?>) ReflectionUtil.invokeMethod(playerIntManager, "getGameMode");
+            Enum<?> enumGamemodePrevious;
+            try {
+                // 1.16+
+                enumGamemodePrevious = (Enum<?>) ReflectionUtil.invokeMethod(playerIntManager, "c");
+            } catch (Exception ignored) {
+                enumGamemodePrevious = null;
+            }
 
             int gamemodeId = player.getGameMode().getValue();
             int dimension = environment.getId();
@@ -170,10 +177,10 @@ public class SpigotSkinRefresher implements Consumer<Player> {
                             try {
                                 Object typeKey = ReflectionUtil.invokeMethod(worldObject, "getTypeKey");
 
-                                respawn = ReflectionUtil.invokeConstructor(playOutRespawn, typeKey, dimensionKey, seedEncrypted, enumGamemode, enumGamemode, debug, flat, true);
+                                respawn = ReflectionUtil.invokeConstructor(playOutRespawn, typeKey, dimensionKey, seedEncrypted, enumGamemode, enumGamemodePrevious, debug, flat, true);
                             } catch (Exception ignored6) {
                                 // Minecraft 1.16.2 changes
-                                respawn = ReflectionUtil.invokeConstructor(playOutRespawn, dimensionManager, dimensionKey, seedEncrypted, enumGamemode, enumGamemode, debug, flat, true);
+                                respawn = ReflectionUtil.invokeConstructor(playOutRespawn, dimensionManager, dimensionKey, seedEncrypted, enumGamemode, enumGamemodePrevious, debug, flat, true);
                             }
                         }
                     }

--- a/src/main/java/net/skinsrestorer/bukkit/skinapplier/SpigotSkinRefresher.java
+++ b/src/main/java/net/skinsrestorer/bukkit/skinapplier/SpigotSkinRefresher.java
@@ -134,13 +134,6 @@ public class SpigotSkinRefresher implements Consumer<Player> {
 
             Object playerIntManager = ReflectionUtil.getFieldByType(craftHandle, "PlayerInteractManager");
             Enum<?> enumGamemode = (Enum<?>) ReflectionUtil.invokeMethod(playerIntManager, "getGameMode");
-            Enum<?> enumGamemodePrevious;
-            try {
-                // 1.16+
-                enumGamemodePrevious = (Enum<?>) ReflectionUtil.invokeMethod(playerIntManager, "c");
-            } catch (Exception ignored) {
-                enumGamemodePrevious = null;
-            }
 
             int gamemodeId = player.getGameMode().getValue();
             int dimension = environment.getId();
@@ -172,6 +165,7 @@ public class SpigotSkinRefresher implements Consumer<Player> {
                             Object dimensionKey = ReflectionUtil.invokeMethod(worldObject, "getDimensionKey");
                             boolean debug = (boolean) ReflectionUtil.invokeMethod(worldObject, "isDebugWorld");
                             boolean flat = (boolean) ReflectionUtil.invokeMethod(worldObject, "isFlatWorld");
+                            Enum<?> enumGamemodePrevious = (Enum<?>) ReflectionUtil.invokeMethod(playerIntManager, "c");
 
                             // Minecraft 1.16.1 changes
                             try {

--- a/src/main/java/net/skinsrestorer/shared/utils/ReflectionUtil.java
+++ b/src/main/java/net/skinsrestorer/shared/utils/ReflectionUtil.java
@@ -201,7 +201,7 @@ public class ReflectionUtil {
                 fields.addAll(getFieldByTypeList(obj, superClass.getSuperclass(), typeName));
             }
 
-            if (fields.isEmpty()) {
+            if (fields.isEmpty() && obj.getClass() == superClass) {
                 throw new FieldNotFoundException("Could not find field of type " + typeName + " in " + obj.getClass().getSimpleName());
             } else {
                 return fields;

--- a/src/main/java/net/skinsrestorer/shared/utils/ReflectionUtil.java
+++ b/src/main/java/net/skinsrestorer/shared/utils/ReflectionUtil.java
@@ -29,9 +29,7 @@ import org.bukkit.Bukkit;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Stream;
 
 public class ReflectionUtil {
@@ -180,20 +178,34 @@ public class ReflectionUtil {
     }
 
     private static Object getFieldByType(Object obj, Class<?> superClass, String typeName) throws ReflectionException {
+        return getFieldByTypeList(obj, superClass, typeName).get(0);
+    }
+
+    public static List<Object> getFieldByTypeList(Object obj, String typeName) throws ReflectionException {
+        return getFieldByTypeList(obj, obj.getClass(), typeName);
+    }
+
+    public static List<Object> getFieldByTypeList(Object obj, Class<?> superClass, String typeName) throws ReflectionException {
+        List<Object> fields = new ArrayList<>();
+
         try {
             for (Field f : superClass.getDeclaredFields()) {
                 if (f.getType().getSimpleName().equalsIgnoreCase(typeName)) {
                     setFieldAccessible(f);
 
-                    return f.get(obj);
+                    fields.add(f.get(obj));
                 }
             }
 
             if (superClass.getSuperclass() != null) {
-                return getFieldByType(obj, superClass.getSuperclass(), typeName);
+                fields.addAll(getFieldByTypeList(obj, superClass.getSuperclass(), typeName));
             }
 
-            throw new FieldNotFoundException("Could not find field of type " + typeName + " in " + obj.getClass().getSimpleName());
+            if (fields.isEmpty()) {
+                throw new FieldNotFoundException("Could not find field of type " + typeName + " in " + obj.getClass().getSimpleName());
+            } else {
+                return fields;
+            }
         } catch (Exception e) {
             throw new ReflectionException(e);
         }


### PR DESCRIPTION
The second gamemode in respawn packet is used in gamemode switcher to quickly switch between current and previous gamemodes using F3+F4 (the previous gamemode is selected by default)