### PR TITLE
applySkin: check if player is online & FIX checkOptFile

### DIFF
--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinApplierBukkit.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinApplierBukkit.java
@@ -188,7 +188,7 @@ public class SkinApplierBukkit {
         disableRemountPlayer = fileDisableRemountPlayer.exists() || fileTxtDisableRemountPlayer.exists();
         enableDismountEntities = fileEnableDismountEntities.exists() || fileTxtEnableDismountEntities.exists();
 
-        log.debug("[Debug] Opt Files: { disableDismountPlayer: " + disableDismountPlayer + ", enableDismountEntities: " + enableDismountEntities + ", disableRemountPlayer: " + disableRemountPlayer + " }");
+        log.debug("[Debug] Opt Files: { disableDismountPlayer: " + disableDismountPlayer + ", disableRemountPlayer: " + disableRemountPlayer + ", enableDismountEntities: " + enableDismountEntities + " }");
         optFileChecked = true;
     }
 }

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinApplierBukkit.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinApplierBukkit.java
@@ -48,8 +48,8 @@ public class SkinApplierBukkit {
     @Setter
     private static boolean optFileChecked;
     private static boolean disableDismountPlayer;
-    private static boolean enableDismountEntities;
     private static boolean disableRemountPlayer;
+    private static boolean enableDismountEntities;
 
     public SkinApplierBukkit(SkinsRestorer plugin, SRLogger log) throws InitializeException {
         this.plugin = plugin;
@@ -178,15 +178,15 @@ public class SkinApplierBukkit {
 
     private void checkOptFile() {
         File fileDisableDismountPlayer = new File(plugin.getDataFolder(), "disablesdismountplayer");
-        File fileEnableDismountEntities = new File(plugin.getDataFolder(), "enablesdismountentities");
         File fileDisableRemountPlayer = new File(plugin.getDataFolder(), "disablesremountplayer");
+        File fileEnableDismountEntities = new File(plugin.getDataFolder(), "enablesdismountentities");
         File fileTxtDisableDismountPlayer = new File(plugin.getDataFolder(), "disableDismountPlayer.txt");
-        File fileTxtEnableDismountEntities = new File(plugin.getDataFolder(), "enableDismountEntities.txt");
         File fileTxtDisableRemountPlayer = new File(plugin.getDataFolder(), "disableRemountPlayer.txt");
+        File fileTxtEnableDismountEntities = new File(plugin.getDataFolder(), "enableDismountEntities.txt");
 
         disableDismountPlayer = fileDisableDismountPlayer.exists() || fileTxtDisableDismountPlayer.exists();
-        enableDismountEntities = fileEnableDismountEntities.exists() || fileTxtEnableDismountEntities.exists();
         disableRemountPlayer = fileDisableRemountPlayer.exists() || fileTxtDisableRemountPlayer.exists();
+        enableDismountEntities = fileEnableDismountEntities.exists() || fileTxtEnableDismountEntities.exists();
 
         log.debug("[Debug] Opt Files: { disableDismountPlayer: " + disableDismountPlayer + ", enableDismountEntities: " + enableDismountEntities + ", disableRemountPlayer: " + disableRemountPlayer + " }");
         optFileChecked = true;

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinApplierBukkit.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinApplierBukkit.java
@@ -128,12 +128,9 @@ public class SkinApplierBukkit {
     public void updateSkin(Player player) {
         if (!player.isOnline())
             return;
-        log.info("[pre] enableRemountPlayer=" + disableRemountPlayer);
 
         if (!checkOptFileChecked)
             checkOptFile();
-
-        log.info("[suf] enableRemountPlayer=" + disableRemountPlayer);
 
         Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> {
             Entity vehicle = player.getVehicle();
@@ -180,7 +177,6 @@ public class SkinApplierBukkit {
     }
 
     private void checkOptFile() {
-        log.info("checkOptFile");
         File fileDisableDismountPlayer = new File(plugin.getDataFolder(), "disablesdismountplayer");
         File fileEnableDismountEntities = new File(plugin.getDataFolder(), "enablesdismountentities");
         File fileDisableRemountPlayer = new File(plugin.getDataFolder(), "disablesremountplayer");
@@ -197,6 +193,7 @@ public class SkinApplierBukkit {
         if (fileDisableRemountPlayer.exists() || filetxtDisableRemountPlayer.exists())
             disableRemountPlayer = true;
 
+        log.debug("[Debug] checkOptFile:\n  disableDismountPlayer = " + disableDismountPlayer + "\n  enableDismountEntities = " + enableDismountEntities + "\n  disableRemountPlayer = " + disableRemountPlayer);
         checkOptFileChecked = true;
     }
 }

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinApplierBukkit.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinApplierBukkit.java
@@ -46,7 +46,7 @@ public class SkinApplierBukkit {
     @Getter
     private final Consumer<Player> refresh;
     @Setter
-    static boolean checkOptFileChecked;
+    private static boolean optFileChecked;
     private static boolean disableDismountPlayer;
     private static boolean enableDismountEntities;
     private static boolean disableRemountPlayer;
@@ -129,7 +129,7 @@ public class SkinApplierBukkit {
         if (!player.isOnline())
             return;
 
-        if (!checkOptFileChecked)
+        if (!optFileChecked)
             checkOptFile();
 
         Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> {
@@ -180,20 +180,15 @@ public class SkinApplierBukkit {
         File fileDisableDismountPlayer = new File(plugin.getDataFolder(), "disablesdismountplayer");
         File fileEnableDismountEntities = new File(plugin.getDataFolder(), "enablesdismountentities");
         File fileDisableRemountPlayer = new File(plugin.getDataFolder(), "disablesremountplayer");
-        File filetxtDisableDismountPlayer = new File(plugin.getDataFolder(), "disablesdismountplayer.txt");
-        File filetxtEnableDismountEntities = new File(plugin.getDataFolder(), "enablesdismountentities.txt");
-        File filetxtDisableRemountPlayer = new File(plugin.getDataFolder(), "disablesremountplayer.txt");
+        File fileTxtDisableDismountPlayer = new File(plugin.getDataFolder(), "disableDismountPlayer.txt");
+        File fileTxtEnableDismountEntities = new File(plugin.getDataFolder(), "enableDismountEntities.txt");
+        File fileTxtDisableRemountPlayer = new File(plugin.getDataFolder(), "disableRemountPlayer.txt");
 
-        if (fileDisableDismountPlayer.exists() || filetxtDisableDismountPlayer.exists())
-            disableDismountPlayer = true;
+        disableDismountPlayer = fileDisableDismountPlayer.exists() || fileTxtDisableDismountPlayer.exists();
+        enableDismountEntities = fileEnableDismountEntities.exists() || fileTxtEnableDismountEntities.exists();
+        disableRemountPlayer = fileDisableRemountPlayer.exists() || fileTxtDisableRemountPlayer.exists();
 
-        if (fileEnableDismountEntities.exists() || filetxtEnableDismountEntities.exists())
-            enableDismountEntities = true;
-
-        if (fileDisableRemountPlayer.exists() || filetxtDisableRemountPlayer.exists())
-            disableRemountPlayer = true;
-
-        log.debug("[Debug] checkOptFile:\n  disableDismountPlayer = " + disableDismountPlayer + "\n  enableDismountEntities = " + enableDismountEntities + "\n  disableRemountPlayer = " + disableRemountPlayer);
-        checkOptFileChecked = true;
+        log.debug("[Debug] Opt Files: { disableDismountPlayer: " + disableDismountPlayer + ", enableDismountEntities: " + enableDismountEntities + ", disableRemountPlayer: " + disableRemountPlayer + " }");
+        optFileChecked = true;
     }
 }

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinApplierBukkit.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinApplierBukkit.java
@@ -22,6 +22,7 @@ package net.skinsrestorer.bukkit;
 import io.papermc.lib.PaperLib;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import net.skinsrestorer.api.bukkit.events.SkinApplyBukkitEvent;
 import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.api.reflection.ReflectionUtil;
@@ -44,10 +45,11 @@ public class SkinApplierBukkit {
     private final SRLogger log;
     @Getter
     private final Consumer<Player> refresh;
-    private boolean checkOptFileChecked = false;
     private boolean disableDismountPlayer;
     private boolean enableDismountEntities;
     private boolean enableRemountPlayer;
+    @Setter
+    static boolean checkOptFileChecked = false;
 
     public SkinApplierBukkit(SkinsRestorer plugin, SRLogger log) throws InitializeException {
         this.plugin = plugin;
@@ -86,6 +88,9 @@ public class SkinApplierBukkit {
      * @param property Property Object
      */
     protected void applySkin(Player player, IProperty property) {
+        if (!player.isOnline())
+            return;
+
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             SkinApplyBukkitEvent applyEvent = new SkinApplyBukkitEvent(player, property);
 

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SrCommand.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SrCommand.java
@@ -28,6 +28,7 @@ import com.google.gson.JsonParser;
 import lombok.RequiredArgsConstructor;
 import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.exception.SkinRequestException;
+import net.skinsrestorer.bukkit.SkinApplierBukkit;
 import net.skinsrestorer.api.reflection.ReflectionUtil;
 import net.skinsrestorer.bukkit.SkinsRestorer;
 import net.skinsrestorer.shared.storage.Config;
@@ -61,6 +62,7 @@ public class SrCommand extends BaseCommand {
     @CommandPermission("%srReload")
     @Description("%helpSrReload")
     public void onReload(CommandSender sender) {
+        SkinApplierBukkit.setCheckOptFileChecked(false);
         Locale.load(plugin.getDataFolder(), logger);
         Config.load(plugin.getDataFolder(), plugin.getResource("config.yml"), logger);
 

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SrCommand.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SrCommand.java
@@ -62,7 +62,7 @@ public class SrCommand extends BaseCommand {
     @CommandPermission("%srReload")
     @Description("%helpSrReload")
     public void onReload(CommandSender sender) {
-        SkinApplierBukkit.setCheckOptFileChecked(false);
+        SkinApplierBukkit.setOptFileChecked(false);
         Locale.load(plugin.getDataFolder(), logger);
         Config.load(plugin.getDataFolder(), plugin.getResource("config.yml"), logger);
 

--- a/shared/src/main/resources/config.yml
+++ b/shared/src/main/resources/config.yml
@@ -139,10 +139,12 @@ MineskinAPIKey: "key"
 # If we break things, you can disable it here.
 
 # Dismounts a mounted (on a horse, or sitting) player when their skin is updated, preventing players from becoming desynced.
+# File override = ./plugins/SkinsRestorer/disablesdismountplayer.txt
 DismountPlayerOnSkinUpdate: true
 
 # Remounts a player that was dismounted after a skin update (above option must be true).
 # Disabling this is only recommended if you use plugins that allow you ride other players, or use sit. Otherwise you could get errors or players could be kicked for flying.
+# File override = ./plugins/SkinsRestorer/disablesdismountplayer.txt
 RemountPlayerOnSkinUpdate: true
 
 # Dismounts all passengers mounting a player (such as plugins that let you ride another player), preventing those players from becoming desynced.

--- a/shared/src/main/resources/config.yml
+++ b/shared/src/main/resources/config.yml
@@ -144,10 +144,11 @@ DismountPlayerOnSkinUpdate: true
 
 # Remounts a player that was dismounted after a skin update (above option must be true).
 # Disabling this is only recommended if you use plugins that allow you ride other players, or use sit. Otherwise you could get errors or players could be kicked for flying.
-# File override = ./plugins/SkinsRestorer/disablesdismountplayer.txt
+# File override = ./plugins/SkinsRestorer/enablesdismountentities.txt
 RemountPlayerOnSkinUpdate: true
 
 # Dismounts all passengers mounting a player (such as plugins that let you ride another player), preventing those players from becoming desynced.
+# File override = ./plugins/SkinsRestorer/disablesremountplayer.txt
 DismountPassengersOnSkinUpdate: false
 
 ###############

--- a/shared/src/main/resources/config.yml
+++ b/shared/src/main/resources/config.yml
@@ -139,16 +139,16 @@ MineskinAPIKey: "key"
 # If we break things, you can disable it here.
 
 # Dismounts a mounted (on a horse, or sitting) player when their skin is updated, preventing players from becoming desynced.
-# File override = ./plugins/SkinsRestorer/disablesdismountplayer.txt
+# File override = ./plugins/SkinsRestorer/disableDismountPlayer.txt
 DismountPlayerOnSkinUpdate: true
 
 # Remounts a player that was dismounted after a skin update (above option must be true).
 # Disabling this is only recommended if you use plugins that allow you ride other players, or use sit. Otherwise you could get errors or players could be kicked for flying.
-# File override = ./plugins/SkinsRestorer/enablesdismountentities.txt
+# File override = ./plugins/SkinsRestorer/disableRemountPlayer.txt
 RemountPlayerOnSkinUpdate: true
 
 # Dismounts all passengers mounting a player (such as plugins that let you ride another player), preventing those players from becoming desynced.
-# File override = ./plugins/SkinsRestorer/disablesremountplayer.txt
+# File override = ./plugins/SkinsRestorer/enableDismountEntities.txt
 DismountPassengersOnSkinUpdate: false
 
 ###############


### PR DESCRIPTION
TODO:
- [x] remove test log

== DEV NOTES ==
I forgot about bungee, will check on this because when no player is online any more for example, this could cause some PMC issues.

Check if player is online before we apply skin
(This is because since the url genskin queue, the player could be leaving during the delay making skinApplier throw error's.)

Fix checkOptFile:
- Recheck checkOptFile on sr reload (bukkit)
- Fixed disablesremountplayer & disableDismountPlayer to work as intended.
- added .txt for: "disablesdismountplayer", "enablesdismountentities" & "disablesremountplayer"

