### PR TITLE
Fix LICENSE modifications

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -631,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    SkinsRestorer allows users to take control of ingame minecraft skins.
+    Copyright (C) 2021 SRTeam
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    <program>  Copyright (C) <year>  <name of author>
+    SkinsRestorer Copyright (C) 2021 SRTeam
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.


### PR DESCRIPTION
Reverts the LICENSE file changes in https://github.com/SkinsRestorer/SkinsRestorerX/commit/0eb36d63c2e72f4085d6ebce13e6d5a9afcd5a92, which reverted the license text to it's default state.