### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ servers.
 
 ## :telescope: Compatibility
 
-- Java 8 till 17 ([AdoptOpenJDK](https://adoptopenjdk.net/)
+- Java 8 till 17 ([Adoptium](https://adoptium.net/)
   | [Oracle Java](https://www.oracle.com/de/java/technologies/javase-downloads.html))
 - Minecraft 1.8.0 - 1.18
 


### PR DESCRIPTION
Changed AdoptOpenJDK to Adoptium since the first one was moved to the second and the first one doesn't have 17JDK.