### PR TITLE
Universal commands

### DIFF
--- a/api/src/main/java/net/skinsrestorer/api/PlayerWrapper.java
+++ b/api/src/main/java/net/skinsrestorer/api/PlayerWrapper.java
@@ -31,7 +31,7 @@ public class PlayerWrapper {
     public PlayerWrapper(Object playerInstance) {
         this.playerInstance = playerInstance;
 
-        this.internalPlayer = SkinsRestorerAPI.getApi().getWrapperFactory().wrap(playerInstance);
+        this.internalPlayer = SkinsRestorerAPI.getApi().getWrapperFactory().wrapPlayer(playerInstance);
     }
 
     public <A> A get(Class<A> playerClass) {

--- a/api/src/main/java/net/skinsrestorer/api/SkinVariant.java
+++ b/api/src/main/java/net/skinsrestorer/api/SkinVariant.java
@@ -17,14 +17,9 @@
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/gpl-3.0.html>.
  */
-package net.skinsrestorer.api.interfaces;
+package net.skinsrestorer.api;
 
-import net.skinsrestorer.api.SkinVariant;
-import net.skinsrestorer.api.exception.SkinRequestException;
-import net.skinsrestorer.api.property.IProperty;
-
-import java.util.UUID;
-
-public interface IMineSkinAPI {
-    IProperty genSkin(String url, SkinVariant skinVariant, UUID methodUUID) throws SkinRequestException;
+public enum SkinVariant {
+    CLASSIC,
+    SLIM
 }

--- a/api/src/main/java/net/skinsrestorer/api/SkinsRestorerAPI.java
+++ b/api/src/main/java/net/skinsrestorer/api/SkinsRestorerAPI.java
@@ -133,18 +133,18 @@ public abstract class SkinsRestorerAPI {
      * Generates a skin using the https://mineskin.org/ api
      * [WARNING] MineSkin api key might be REQUIRED in the future.
      *
-     * @param url      pointing to a skin image url
-     * @param skinType can be null, steve or slim
+     * @param url         pointing to a skin image url
+     * @param skinVariant can be null, steve or slim
      * @return Custom skin property containing "value" and "signature"
      * @throws SkinRequestException on error
      */
-    public IProperty genSkinUrl(String url, @Nullable String skinType) throws SkinRequestException {
-        return mineSkinAPI.genSkin(url, skinType, null);
+    public IProperty genSkinUrl(String url, @Nullable SkinVariant skinVariant) throws SkinRequestException {
+        return mineSkinAPI.genSkin(url, skinVariant, null);
     }
 
     /**
      * Returns a https://textures.minecraft.net/id based on skin
-     * This is Usefull for skull plugins like Dynmap or DiscordSRV
+     * This is useful for skull plugins like Dynmap or DiscordSRV
      * for example https://mc-heads.net/avatar/%texture_id%/%size%.png
      *
      * @param skinName

--- a/api/src/main/java/net/skinsrestorer/api/SkinsRestorerAPI.java
+++ b/api/src/main/java/net/skinsrestorer/api/SkinsRestorerAPI.java
@@ -154,8 +154,8 @@ public abstract class SkinsRestorerAPI {
         IProperty skin = getSkinData(skinName);
         if (skin == null)
             return null;
-        byte[] decoded = Base64.getDecoder().decode(skin.getValue());
-        String decodedString = new String(decoded);
+
+        String decodedString = new String(Base64.getDecoder().decode(skin.getValue()));
         JsonObject jsonObject = JsonParser.parseString(decodedString).getAsJsonObject();
         String decodedSkin = jsonObject.getAsJsonObject().get("textures").getAsJsonObject().get("SKIN").getAsJsonObject().get("url").toString();
         return decodedSkin.substring(1, decodedSkin.length() - 1);

--- a/api/src/main/java/net/skinsrestorer/api/SkinsRestorerAPI.java
+++ b/api/src/main/java/net/skinsrestorer/api/SkinsRestorerAPI.java
@@ -166,6 +166,10 @@ public abstract class SkinsRestorerAPI {
         skinStorage.getSkinForPlayer(skinName);
     }
 
+    public IProperty createProperty(String name, String value, String signature) {
+        return mojangAPI.createProperty(name, value, signature);
+    }
+
     public void removeSkin(String playerName) {
         skinStorage.removeSkin(playerName);
     }

--- a/api/src/main/java/net/skinsrestorer/api/interfaces/IMojangAPI.java
+++ b/api/src/main/java/net/skinsrestorer/api/interfaces/IMojangAPI.java
@@ -25,4 +25,6 @@ import java.util.Optional;
 
 public interface IMojangAPI {
     Optional<IProperty> getProfile(String uuid);
+
+    IProperty createProperty(String name, String value, String signature);
 }

--- a/api/src/main/java/net/skinsrestorer/api/interfaces/ISRCommandSender.java
+++ b/api/src/main/java/net/skinsrestorer/api/interfaces/ISRCommandSender.java
@@ -29,4 +29,8 @@ public interface ISRCommandSender {
     default boolean isConsole() {
         return false;
     }
+
+    default boolean equalsPlayer(ISRPlayer player) {
+        return getName().equals(player.getName());
+    }
 }

--- a/api/src/main/java/net/skinsrestorer/api/interfaces/ISRCommandSender.java
+++ b/api/src/main/java/net/skinsrestorer/api/interfaces/ISRCommandSender.java
@@ -25,4 +25,8 @@ public interface ISRCommandSender {
     String getName();
 
     boolean hasPermission(String permission);
+
+    default boolean isConsole() {
+        return false;
+    }
 }

--- a/api/src/main/java/net/skinsrestorer/api/interfaces/ISRPlayer.java
+++ b/api/src/main/java/net/skinsrestorer/api/interfaces/ISRPlayer.java
@@ -21,7 +21,7 @@ package net.skinsrestorer.api.interfaces;
 
 import net.skinsrestorer.api.PlayerWrapper;
 
-public interface ISRPlayer {
+public interface ISRPlayer extends ISRCommandSender {
     PlayerWrapper getWrapper();
 
     String getName();

--- a/api/src/main/java/net/skinsrestorer/api/interfaces/IWrapperFactory.java
+++ b/api/src/main/java/net/skinsrestorer/api/interfaces/IWrapperFactory.java
@@ -20,5 +20,5 @@
 package net.skinsrestorer.api.interfaces;
 
 public interface IWrapperFactory {
-    ISRPlayer wrap(Object playerInstance);
+    ISRPlayer wrapPlayer(Object playerInstance);
 }

--- a/buildSrc/src/main/kotlin/extensions.kt
+++ b/buildSrc/src/main/kotlin/extensions.kt
@@ -1,5 +1,4 @@
-import io.papermc.paperweight.util.constants.*
-import io.papermc.paperweight.userdev.PaperweightUserExtension
+import io.papermc.paperweight.util.constants.DEV_BUNDLE_CONFIG
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ExternalModuleDependency

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinsRestorer.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinsRestorer.java
@@ -36,6 +36,7 @@ import net.skinsrestorer.bukkit.listener.PlayerJoin;
 import net.skinsrestorer.bukkit.listener.ProtocolLibJoinListener;
 import net.skinsrestorer.bukkit.utils.BukkitConsoleImpl;
 import net.skinsrestorer.bukkit.utils.UpdateDownloaderGithub;
+import net.skinsrestorer.bukkit.utils.WrapperBukkit;
 import net.skinsrestorer.shared.exception.InitializeException;
 import net.skinsrestorer.shared.interfaces.ISRPlugin;
 import net.skinsrestorer.shared.storage.Config;
@@ -449,26 +450,11 @@ public class SkinsRestorer extends JavaPlugin implements ISRPlugin {
 
     private static class WrapperFactoryBukkit extends WrapperFactory {
         @Override
-        public ISRPlayer wrap(Object playerInstance) {
+        public ISRPlayer wrapPlayer(Object playerInstance) {
             if (playerInstance instanceof Player) {
                 Player player = (Player) playerInstance;
 
-                return new ISRPlayer() {
-                    @Override
-                    public PlayerWrapper getWrapper() {
-                        return new PlayerWrapper(playerInstance);
-                    }
-
-                    @Override
-                    public String getName() {
-                        return player.getName();
-                    }
-
-                    @Override
-                    public void sendMessage(String message) {
-                        player.sendMessage(message);
-                    }
-                };
+                return WrapperBukkit.wrapPlayer(player);
             } else {
                 throw new IllegalArgumentException("Player instance is not valid!");
             }

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinsRestorer.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinsRestorer.java
@@ -64,9 +64,11 @@ import org.inventivetalent.update.spiget.UpdateCallback;
 
 import java.io.*;
 import java.nio.file.Files;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 @Getter
 @SuppressWarnings("Duplicates")
@@ -104,6 +106,16 @@ public class SkinsRestorer extends JavaPlugin implements ISRPlugin {
     @Override
     public String getVersion() {
         return getDescription().getVersion();
+    }
+
+    @Override
+    public void runAsync(Runnable runnable) {
+        getServer().getScheduler().runTaskAsynchronously(this, runnable);
+    }
+
+    @Override
+    public Collection<ISRPlayer> getOnlinePlayers() {
+        return getServer().getOnlinePlayers().stream().map(WrapperBukkit::wrapPlayer).collect(Collectors.toList());
     }
 
     @Override
@@ -328,7 +340,7 @@ public class SkinsRestorer extends JavaPlugin implements ISRPlugin {
 
         skinCommand = new SkinCommand(this);
         manager.registerCommand(skinCommand);
-        manager.registerCommand(new SrCommand(this, srLogger));
+        manager.registerCommand(new SrCommand(this));
         manager.registerCommand(new GUICommand(this, new SkinsGUI(this, srLogger)));
     }
 

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinsRestorer.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinsRestorer.java
@@ -325,7 +325,7 @@ public class SkinsRestorer extends JavaPlugin implements ISRPlugin {
 
         prepareACF(manager, srLogger);
 
-        skinCommand = new SkinCommand(this, srLogger);
+        skinCommand = new SkinCommand(this);
         manager.registerCommand(skinCommand);
         manager.registerCommand(new SrCommand(this, srLogger));
         manager.registerCommand(new GUICommand(this, new SkinsGUI(this, srLogger)));

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
@@ -30,6 +30,7 @@ import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.interfaces.ISRCommandSender;
 import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.bukkit.SkinsRestorer;
+import net.skinsrestorer.shared.commands.ISkinCommand;
 import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.storage.CooldownStorage;
 import net.skinsrestorer.shared.storage.Locale;
@@ -44,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 @CommandAlias("skin")
 @CommandPermission("%skin")
-public class SkinCommand extends BaseCommand {
+public class SkinCommand extends BaseCommand implements ISkinCommand {
     private final SkinsRestorer plugin;
     private final SRLogger log;
 

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
@@ -26,6 +26,7 @@ import co.aikar.commands.bukkit.contexts.OnlinePlayer;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.skinsrestorer.api.PlayerWrapper;
+import net.skinsrestorer.api.SkinVariant;
 import net.skinsrestorer.api.SkinsRestorerAPI;
 import net.skinsrestorer.bukkit.SkinsRestorer;
 import net.skinsrestorer.shared.commands.ISkinCommand;
@@ -108,8 +109,8 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @CommandCompletion("@players @skin")
     @Description("%helpSkinSetOther")
     @Syntax("%SyntaxSkinSetOther")
-    public void onSkinSetOther(CommandSender sender, OnlinePlayer target, String skin, @Optional SkinType skinType) {
-        onSkinSetOther(wrapCommandSender(sender), wrapPlayer(target.getPlayer()), skin, skinType);
+    public void onSkinSetOther(CommandSender sender, OnlinePlayer target, String skin, @Optional SkinVariant skinVariant) {
+        onSkinSetOther(wrapCommandSender(sender), wrapPlayer(target.getPlayer()), skin, skinVariant);
     }
 
     @Subcommand("url")
@@ -117,8 +118,8 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @CommandCompletion("@skinUrl")
     @Description("%helpSkinSetUrl")
     @Syntax("%SyntaxSkinUrl")
-    public void onSkinSetUrl(Player player, String url, @Optional SkinType skinType) {
-        onSkinSetUrl(wrapPlayer(player), url, skinType);
+    public void onSkinSetUrl(Player player, String url, @Optional SkinVariant skinVariant) {
+        onSkinSetUrl(wrapPlayer(player), url, skinVariant);
     }
 
     @Override

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
@@ -110,7 +110,6 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Syntax("%SyntaxSkinSetOther")
     public void onSkinSetOther(CommandSender sender, OnlinePlayer target, String skin, @Optional SkinType skinType) {
         onSkinSetOther(wrapCommandSender(sender), wrapPlayer(target.getPlayer()), skin, skinType);
-
     }
 
     @Subcommand("url")

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
@@ -127,9 +127,4 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
         SkinsRestorerAPI.getApi().applySkin(player, emptySkin);
         plugin.getSkinApplierBukkit().updateSkin(player.get(Player.class)); // TODO: make not platform specific
     }
-
-    @Override
-    public void runAsync(Runnable runnable) {
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, runnable);
-    }
 }

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
@@ -24,6 +24,7 @@ import co.aikar.commands.CommandHelp;
 import co.aikar.commands.InvalidCommandArgument;
 import co.aikar.commands.annotation.*;
 import co.aikar.commands.bukkit.contexts.OnlinePlayer;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.exception.SkinRequestException;
@@ -46,6 +47,7 @@ import java.util.concurrent.TimeUnit;
 @CommandAlias("skin")
 @CommandPermission("%skin")
 public class SkinCommand extends BaseCommand implements ISkinCommand {
+    @Getter
     private final SkinsRestorer plugin;
     private final SRLogger log;
 
@@ -67,8 +69,9 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @HelpCommand
     @Syntax(" [help]")
     public void onHelp(CommandSender sender, CommandHelp help) {
+        ISRCommandSender wrapped = wrap(sender);
         if (Config.ENABLE_CUSTOM_HELP)
-            sendHelp(sender);
+            sendHelp(wrapped);
         else
             help.showHelp();
     }
@@ -86,6 +89,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Syntax("%SyntaxSkinClearOther")
     @Description("%helpSkinClearOther")
     public void onSkinClearOther(CommandSender sender, @Single OnlinePlayer target) {
+        ISRCommandSender wrapped = wrap(sender);
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             if (!sender.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(sender.getName())) {
                 sender.sendMessage(Locale.SKIN_COOLDOWN.replace("%s", "" + CooldownStorage.getCooldown(sender.getName())));
@@ -122,6 +126,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Description("%helpSkinUpdateOther")
     @Syntax("%SyntaxSkinUpdateOther")
     public void onSkinUpdateOther(CommandSender sender, @Single OnlinePlayer target) {
+        ISRCommandSender wrapped = wrap(sender);
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             if (!sender.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(sender.getName())) {
                 sender.sendMessage(Locale.SKIN_COOLDOWN.replace("%s", "" + CooldownStorage.getCooldown(sender.getName())));
@@ -181,6 +186,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Description("%helpSkinSetOther")
     @Syntax("%SyntaxSkinSetOther")
     public void onSkinSetOther(CommandSender sender, OnlinePlayer target, String skin, @Optional SkinType skinType) {
+        ISRCommandSender wrapped = wrap(sender);
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
             final Player player = target.getPlayer();
             if (Config.PER_SKIN_PERMISSIONS && !sender.hasPermission("skinsrestorer.skin." + skin)) {
@@ -208,10 +214,6 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
         }
 
         onSkinSetOther(player, new OnlinePlayer(player), url, skinType);
-    }
-
-    private boolean setSkin(CommandSender sender, Player player, String skin) {
-        return setSkin(wrap(sender), new PlayerWrapper(player), skin, true, false, null);
     }
 
     // if save is false, we won't save the skin skin name
@@ -303,21 +305,6 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
         return false;
     }
 
-    private void rollback(String pName, String oldSkinName, boolean save) {
-        if (save)
-            plugin.getSkinStorage().setSkinName(pName, oldSkinName);
-    }
-
-    private void sendHelp(CommandSender sender) {
-        if (!Locale.SR_LINE.isEmpty())
-            sender.sendMessage(Locale.SR_LINE);
-
-        sender.sendMessage(Locale.CUSTOM_HELP_IF_ENABLED.replace("%ver%", plugin.getVersion()));
-
-        if (!Locale.SR_LINE.isEmpty())
-            sender.sendMessage(Locale.SR_LINE);
-    }
-
     private ISRCommandSender wrap(CommandSender sender) {
         return new ISRCommandSender() {
             @Override
@@ -335,11 +322,5 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
                 return sender.hasPermission(permission);
             }
         };
-    }
-
-    @SuppressWarnings("unused")
-    public enum SkinType {
-        STEVE,
-        SLIM,
     }
 }

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
@@ -25,9 +25,9 @@ import co.aikar.commands.annotation.*;
 import co.aikar.commands.bukkit.contexts.OnlinePlayer;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.SkinVariant;
 import net.skinsrestorer.api.SkinsRestorerAPI;
+import net.skinsrestorer.api.interfaces.ISRPlayer;
 import net.skinsrestorer.bukkit.SkinsRestorer;
 import net.skinsrestorer.shared.commands.ISkinCommand;
 import org.bukkit.command.CommandSender;
@@ -123,8 +123,8 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     }
 
     @Override
-    public void clearSkin(PlayerWrapper player) {
-        SkinsRestorerAPI.getApi().applySkin(player, emptySkin);
-        plugin.getSkinApplierBukkit().updateSkin(player.get(Player.class)); // TODO: make not platform specific
+    public void clearSkin(ISRPlayer player) {
+        SkinsRestorerAPI.getApi().applySkin(player.getWrapper(), emptySkin);
+        plugin.getSkinApplierBukkit().updateSkin(player.getWrapper().get(Player.class)); // TODO: make not platform specific
     }
 }

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SkinCommand.java
@@ -27,9 +27,9 @@ import co.aikar.commands.bukkit.contexts.OnlinePlayer;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.skinsrestorer.api.PlayerWrapper;
+import net.skinsrestorer.api.SkinsRestorerAPI;
 import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.interfaces.ISRCommandSender;
-import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.bukkit.SkinsRestorer;
 import net.skinsrestorer.shared.commands.ISkinCommand;
 import net.skinsrestorer.shared.storage.Config;
@@ -40,8 +40,6 @@ import net.skinsrestorer.shared.utils.log.SRLogger;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-
-import java.util.concurrent.TimeUnit;
 
 @RequiredArgsConstructor
 @CommandAlias("skin")
@@ -196,7 +194,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
                 }
             }
 
-            if (setSkin(wrap(sender), new PlayerWrapper(player), skin, true, false, skinType) && (sender != player))
+            if (setSkin(wrapped, new PlayerWrapper(player), skin, true, false, skinType) && (sender != player))
                 sender.sendMessage(Locale.ADMIN_SET_SKIN.replace("%player", player.getName()));
         });
     }
@@ -216,95 +214,6 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
         onSkinSetOther(player, new OnlinePlayer(player), url, skinType);
     }
 
-    // if save is false, we won't save the skin skin name
-    // because default skin names shouldn't be saved as the users custom skin
-    // TODO: align #setSkin() with the other platforms so that it match and can be merged on a later stage!
-    private boolean setSkin(ISRCommandSender sender, PlayerWrapper player, String skin, boolean save, boolean clear, SkinType skinType) {
-        if (skin.equalsIgnoreCase("null")) {
-            sender.sendMessage(Locale.INVALID_PLAYER.replace("%player", skin));
-            return false;
-        }
-
-        if (Config.DISABLED_SKINS_ENABLED && !clear && !sender.hasPermission("skinsrestorer.bypassdisabled")) {
-            for (String dskin : Config.DISABLED_SKINS)
-                if (skin.equalsIgnoreCase(dskin)) {
-                    sender.sendMessage(Locale.SKIN_DISABLED);
-                    return false;
-                }
-        }
-
-        final String senderName = sender.getName();
-        if (!sender.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(senderName)) {
-            sender.sendMessage(Locale.SKIN_COOLDOWN.replace("%s", "" + CooldownStorage.getCooldown(senderName)));
-            return false;
-        }
-
-        CooldownStorage.setCooldown(senderName, Config.SKIN_CHANGE_COOLDOWN, TimeUnit.SECONDS);
-
-        final String pName = player.getName();
-        final java.util.Optional<String> oldSkinName = plugin.getSkinStorage().getSkinName(pName);
-        if (C.validUrl(skin)) {
-            if (!sender.hasPermission("skinsrestorer.command.set.url")
-                    && !Config.SKIN_WITHOUT_PERM
-                    && !clear) {//ignore /skin clear when defaultSkin = url
-                sender.sendMessage(Locale.PLAYER_HAS_NO_PERMISSION_URL);
-                CooldownStorage.resetCooldown(senderName);
-                return false;
-            }
-
-            if (!C.allowedSkinUrl(skin)) {
-                sender.sendMessage(Locale.SKINURL_DISALLOWED);
-                CooldownStorage.resetCooldown(senderName);
-                return false;
-            }
-
-            try {
-                sender.sendMessage(Locale.MS_UPDATING_SKIN);
-                String skinentry = " " + pName; // so won't overwrite premium playernames
-                if (skinentry.length() > 16) // max len of 16 char
-                    skinentry = skinentry.substring(0, 16);
-
-                IProperty generatedSkin = plugin.getMineSkinAPI().genSkin(skin, String.valueOf(skinType), null);
-                plugin.getSkinStorage().setSkinData(skinentry, generatedSkin,
-                        System.currentTimeMillis() + (100L * 365 * 24 * 60 * 60 * 1000)); // "generate" and save skin for 100 years
-                plugin.getSkinStorage().setSkinName(pName, skinentry); // set player to "whitespaced" name then reload skin
-                plugin.getSkinsRestorerAPI().applySkin(player, generatedSkin);
-                if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
-                    player.sendMessage(Locale.SKIN_CHANGE_SUCCESS.replace("%skin", "skinUrl"));
-                return true;
-            } catch (SkinRequestException e) {
-                sender.sendMessage(e.getMessage());
-            } catch (Exception e) {
-                log.debug("[ERROR] Exception: could not generate skin url:" + skin + "\nReason= " + e.getMessage());
-                sender.sendMessage(Locale.ERROR_INVALID_URLSKIN);
-            }
-        } else {
-            //If skin is not a url, its a username
-            try {
-                if (save)
-                    plugin.getSkinStorage().setSkinName(pName, skin);
-
-                // TODO: #getSkinForPlayer() is nested and on different places around bungee/sponge/velocity
-                plugin.getSkinsRestorerAPI().applySkin(player, skin);
-                if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
-                    player.sendMessage(Locale.SKIN_CHANGE_SUCCESS.replace("%skin", skin)); // TODO:: should this not be sender? -> hidden skin set?
-                return true;
-            } catch (SkinRequestException e) {
-                if (clear) {
-                    plugin.getSkinsRestorerAPI().applySkin(player, plugin.getMojangAPI().createProperty("textures", "", ""));
-                    plugin.getSkinApplierBukkit().updateSkin(player.get(Player.class));
-
-                    return true;
-                }
-                sender.sendMessage(e.getMessage());
-            }
-        }
-        // set CoolDown to ERROR_COOLDOWN and rollback to old skin on exception
-        CooldownStorage.setCooldown(senderName, Config.SKIN_ERROR_COOLDOWN, TimeUnit.SECONDS);
-        rollback(pName, oldSkinName.orElse(pName), save);
-        return false;
-    }
-
     private ISRCommandSender wrap(CommandSender sender) {
         return new ISRCommandSender() {
             @Override
@@ -322,5 +231,11 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
                 return sender.hasPermission(permission);
             }
         };
+    }
+
+    @Override
+    public void clearSkin(PlayerWrapper player) {
+        SkinsRestorerAPI.getApi().applySkin(player, emptySkin);
+        plugin.getSkinApplierBukkit().updateSkin(player.get(Player.class)); // TODO: make not platform specific
     }
 }

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SrCommand.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SrCommand.java
@@ -27,6 +27,7 @@ import com.mojang.authlib.properties.Property;
 import com.mojang.authlib.properties.PropertyMap;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.api.SkinVariant;
 import net.skinsrestorer.api.interfaces.ISRPlayer;
 import net.skinsrestorer.api.property.GenericProperty;
 import net.skinsrestorer.api.property.IProperty;
@@ -104,17 +105,17 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @CommandPermission("%srCreateCustom")
     @CommandCompletion("@skinName @skinUrl")
     @Description("%helpSrCreateCustom")
-    @Syntax(" <skinName> <skinUrl> [steve/slim]")
-    public void onCreateCustom(CommandSender sender, String name, String skinUrl, @Optional SkinType skinType) {
-        onCreateCustom(wrapCommandSender(sender), name, skinUrl, skinType);
+    @Syntax(" <skinName> <skinUrl> [classic/slim]")
+    public void onCreateCustom(CommandSender sender, String name, String skinUrl, @Optional SkinVariant skinVariant) {
+        onCreateCustom(wrapCommandSender(sender), name, skinUrl, skinVariant);
     }
 
     @Subcommand("setskinall")
     @CommandCompletion("@Skin")
     @Description("Set the skin to evey player")
-    @Syntax(" <Skin / Url> [steve/slim]")
-    public void onSetSkinAll(CommandSender sender, String skinUrl, @Optional SkinType skinType) {
-        onSetSkinAll(wrapCommandSender(sender), skinUrl, skinType);
+    @Syntax(" <Skin / Url> [classic/slim]")
+    public void onSetSkinAll(CommandSender sender, String skinUrl, @Optional SkinVariant skinVariant) {
+        onSetSkinAll(wrapCommandSender(sender), skinUrl, skinVariant);
     }
 
     @Override

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SrCommand.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SrCommand.java
@@ -23,12 +23,24 @@ import co.aikar.commands.BaseCommand;
 import co.aikar.commands.CommandHelp;
 import co.aikar.commands.annotation.*;
 import co.aikar.commands.bukkit.contexts.OnlinePlayer;
+import com.mojang.authlib.properties.Property;
+import com.mojang.authlib.properties.PropertyMap;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.api.interfaces.ISRPlayer;
+import net.skinsrestorer.api.property.GenericProperty;
+import net.skinsrestorer.api.property.IProperty;
+import net.skinsrestorer.api.reflection.ReflectionUtil;
+import net.skinsrestorer.api.reflection.exception.ReflectionException;
 import net.skinsrestorer.bukkit.SkinApplierBukkit;
 import net.skinsrestorer.bukkit.SkinsRestorer;
 import net.skinsrestorer.shared.commands.ISRCommand;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static net.skinsrestorer.bukkit.utils.WrapperBukkit.wrapCommandSender;
 import static net.skinsrestorer.bukkit.utils.WrapperBukkit.wrapPlayer;
@@ -118,5 +130,22 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Override
     public String getProxyMode() {
         return String.valueOf(plugin.isBungeeEnabled());
+    }
+
+    @Override
+    public List<IProperty> getPropertiesOfPlayer(ISRPlayer player) {
+        try {
+            PropertyMap propertyMap = plugin.getSkinApplierBukkit().getGameProfile(player.getWrapper().get(Player.class)).getProperties();
+            Collection<?> props = (Collection<?>) ReflectionUtil.invokeMethod(propertyMap.getClass(), propertyMap, "get",
+                    new Class<?>[]{Object.class}, "textures");
+
+            return props.stream().map(prop -> {
+                Property property = (Property) prop;
+                return new GenericProperty(property.getName(), property.getValue(), property.getSignature());
+            }).collect(Collectors.toList());
+        } catch (ReflectionException e) {
+            e.printStackTrace();
+            return null;
+        }
     }
 }

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SrCommand.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SrCommand.java
@@ -23,94 +23,41 @@ import co.aikar.commands.BaseCommand;
 import co.aikar.commands.CommandHelp;
 import co.aikar.commands.annotation.*;
 import co.aikar.commands.bukkit.contexts.OnlinePlayer;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.mojang.authlib.properties.PropertyMap;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.skinsrestorer.api.PlayerWrapper;
-import net.skinsrestorer.api.exception.SkinRequestException;
-import net.skinsrestorer.api.property.IProperty;
-import net.skinsrestorer.api.reflection.ReflectionUtil;
 import net.skinsrestorer.bukkit.SkinApplierBukkit;
 import net.skinsrestorer.bukkit.SkinsRestorer;
 import net.skinsrestorer.shared.commands.ISRCommand;
-import net.skinsrestorer.shared.storage.Config;
-import net.skinsrestorer.shared.storage.Locale;
-import net.skinsrestorer.shared.utils.C;
-import net.skinsrestorer.shared.utils.connections.ServiceChecker;
-import net.skinsrestorer.shared.utils.log.SRLogger;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.command.ConsoleCommandSender;
-import org.bukkit.entity.Player;
 
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.List;
+import static net.skinsrestorer.bukkit.utils.WrapperBukkit.wrapCommandSender;
+import static net.skinsrestorer.bukkit.utils.WrapperBukkit.wrapPlayer;
 
 @RequiredArgsConstructor
 @CommandAlias("sr|skinsrestorer")
 @CommandPermission("%sr")
 public class SrCommand extends BaseCommand implements ISRCommand {
+    @Getter
     private final SkinsRestorer plugin;
-    private final SRLogger logger;
 
     @HelpCommand
     @Syntax(" [help]")
     public void onHelp(CommandSender sender, CommandHelp help) {
-        help.showHelp();
+        onHelp(wrapCommandSender(sender), help);
     }
 
     @Subcommand("reload")
     @CommandPermission("%srReload")
     @Description("%helpSrReload")
     public void onReload(CommandSender sender) {
-        SkinApplierBukkit.setOptFileChecked(false);
-        Locale.load(plugin.getDataFolder(), logger);
-        Config.load(plugin.getDataFolder(), plugin.getResource("config.yml"), logger);
-
-        plugin.prepareACF(plugin.getManager(), plugin.getSrLogger());
-
-        sender.sendMessage(Locale.RELOAD);
+        onReload(wrapCommandSender(sender));
     }
 
     @Subcommand("status")
     @CommandPermission("%srStatus")
     @Description("%helpSrStatus")
     public void onStatus(CommandSender sender) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            sender.sendMessage("§3----------------------------------------------");
-            sender.sendMessage("§7Checking needed services for SR to work properly...");
-
-            ServiceChecker checker = new ServiceChecker();
-            checker.setMojangAPI(plugin.getMojangAPI());
-            checker.checkServices();
-
-            ServiceChecker.ServiceCheckResponse response = checker.getResponse();
-            List<String> results = response.getResults();
-
-            if (Config.DEBUG || !(response.getWorkingUUID().get() >= 1) || !(response.getWorkingProfile().get() >= 1))
-                for (String result : results) {
-                    if (Config.DEBUG || result.contains("✘"))
-                        sender.sendMessage(result);
-                }
-
-            sender.sendMessage("§7Working UUID API count: §6" + response.getWorkingUUID());
-            sender.sendMessage("§7Working Profile API count: §6" + response.getWorkingProfile());
-
-            if (response.getWorkingUUID().get() >= 1 && response.getWorkingProfile().get() >= 1)
-                sender.sendMessage("§aThe plugin currently is in a working state.");
-            else
-                sender.sendMessage("§cPlugin currently can't fetch new skins. \n Connection is likely blocked because of firewall. \n Please See http://skinsrestorer.net/firewall for more info");
-            sender.sendMessage("§3----------------------------------------------");
-            sender.sendMessage("§7SkinsRestorer §6v" + plugin.getVersion());
-            sender.sendMessage("§7Server: §6" + plugin.getServer().getVersion());
-            sender.sendMessage("§7BungeeMode: §6" + plugin.isBungeeEnabled());
-            sender.sendMessage("§7Finished checking services.");
-            sender.sendMessage("§3----------------------------------------------");
-        });
+        onStatus(wrapCommandSender(sender));
     }
 
     @Subcommand("drop|remove")
@@ -119,17 +66,7 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("%helpSrDrop")
     @Syntax(" <player|skin> <target> [target2]")
     public void onDrop(CommandSender sender, PlayerOrSkin playerOrSkin, String[] targets) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            if (playerOrSkin == PlayerOrSkin.PLAYER)
-                for (String targetPlayer : targets)
-                    plugin.getSkinStorage().removeSkin(targetPlayer);
-            else
-                for (String targetSkin : targets)
-                    plugin.getSkinStorage().removeSkinData(targetSkin);
-
-            String targetList = Arrays.toString(targets).substring(1, Arrays.toString(targets).length() - 1);
-            sender.sendMessage(Locale.DATA_DROPPED.replace("%playerOrSkin", playerOrSkin.toString()).replace("%targets", targetList));
-        });
+        onDrop(wrapCommandSender(sender), playerOrSkin, targets);
     }
 
 
@@ -139,46 +76,7 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("%helpSrProps")
     @Syntax(" <target>")
     public void onProps(CommandSender sender, @Single OnlinePlayer target) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            try {
-                PropertyMap propertyMap = plugin.getSkinApplierBukkit().getGameProfile(target.player).getProperties();
-                Collection<?> props = (Collection<?>) ReflectionUtil.invokeMethod(propertyMap.getClass(), propertyMap, "get",
-                        new Class<?>[]{Object.class}, "textures");
-
-                if (props == null || props.isEmpty()) {
-                    sender.sendMessage(Locale.NO_SKIN_DATA);
-                    return;
-                }
-
-                for (Object prop : props) {
-                    String name = (String) ReflectionUtil.invokeMethod(prop, "getName");
-                    String value = (String) ReflectionUtil.invokeMethod(prop, "getValue");
-                    String signature = (String) ReflectionUtil.invokeMethod(prop, "getSignature");
-
-                    byte[] decoded = Base64.getDecoder().decode(value);
-                    String decodedString = new String(decoded);
-                    JsonObject jsonObject = JsonParser.parseString(decodedString).getAsJsonObject();
-                    String decodedSkin = jsonObject.getAsJsonObject().get("textures").getAsJsonObject().get("SKIN").getAsJsonObject().get("url").toString();
-                    long timestamp = Long.parseLong(jsonObject.getAsJsonObject().get("timestamp").toString());
-                    String requestDate = new java.text.SimpleDateFormat("MM/dd/yyyy HH:mm:ss").format(new java.util.Date(timestamp));
-
-                    sender.sendMessage("§aRequest time: §e" + requestDate);
-                    sender.sendMessage("§aProfileId: §e" + jsonObject.getAsJsonObject().get("profileId").toString());
-                    sender.sendMessage("§aName: §e" + jsonObject.getAsJsonObject().get("profileName").toString());
-                    sender.sendMessage("§aSkinTexture: §e" + decodedSkin.substring(1, decodedSkin.length() - 1));
-                    sender.sendMessage("§cMore info in console!");
-
-                    // Console
-                    logger.info("§aName: §8" + name);
-                    logger.info("§aValue : §8" + value);
-                    logger.info("§aSignature : §8" + signature);
-                    logger.info("§aValue Decoded: §e" + Arrays.toString(decoded));
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
-                sender.sendMessage(Locale.NO_SKIN_DATA);
-            }
-        });
+        onProps(wrapCommandSender(sender), wrapPlayer(target.getPlayer()));
     }
 
     @Subcommand("applyskin")
@@ -187,22 +85,7 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("%helpSrApplySkin")
     @Syntax(" <target>")
     public void onApplySkin(CommandSender sender, @Single OnlinePlayer target) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            try {
-                final Player player = target.getPlayer();
-                final String name = player.getName();
-                final String skin = plugin.getSkinStorage().getDefaultSkinName(name);
-
-                if (C.validUrl(skin)) {
-                    plugin.getSkinsRestorerAPI().applySkin(new PlayerWrapper(player), plugin.getMineSkinAPI().genSkin(skin, null, null));
-                } else {
-                    plugin.getSkinsRestorerAPI().applySkin(new PlayerWrapper(player), skin);
-                }
-                sender.sendMessage("success: player skin has been refreshed!");
-            } catch (Exception ignored) {
-                sender.sendMessage("ERROR: player skin could NOT be refreshed!");
-            }
-        });
+        onApplySkin(wrapCommandSender(sender), wrapPlayer(target.getPlayer()));
     }
 
     @Subcommand("createcustom")
@@ -211,67 +94,29 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("%helpSrCreateCustom")
     @Syntax(" <skinName> <skinUrl> [steve/slim]")
     public void onCreateCustom(CommandSender sender, String name, String skinUrl, @Optional SkinType skinType) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            try {
-                if (C.validUrl(skinUrl)) {
-                    plugin.getSkinStorage().setSkinData(name, plugin.getMineSkinAPI().genSkin(skinUrl, String.valueOf(skinType), null),
-                            System.currentTimeMillis() + (100L * 365 * 24 * 60 * 60 * 1000)); // "generate" and save skin for 100 years
-                    sender.sendMessage(Locale.SUCCESS_CREATE_SKIN.replace("%skin", name));
-                } else {
-                    sender.sendMessage(Locale.ERROR_INVALID_URLSKIN);
-                }
-            } catch (SkinRequestException e) {
-                sender.sendMessage(e.getMessage());
-            }
-        });
+        onCreateCustom(wrapCommandSender(sender), name, skinUrl, skinType);
     }
 
     @Subcommand("setskinall")
     @CommandCompletion("@Skin")
     @Description("Set the skin to evey player")
     @Syntax(" <Skin / Url> [steve/slim]")
-    public void onSetSkinAll(CommandSender sender, String skin, @Optional SkinType skinType) {
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
-            if (!(sender instanceof ConsoleCommandSender)) {
-                sender.sendMessage(Locale.PREFIX + ChatColor.DARK_RED + "Only console may execute this command!");
-                return;
-            }
-
-            String skinName = " ·setSkinAll";
-            try {
-                IProperty skinProps = null;
-                if (C.validUrl(skin)) {
-                    skinProps = plugin.getMineSkinAPI().genSkin(skin, String.valueOf(skinType), null);
-                } else {
-                    skinProps = plugin.getMojangAPI().getSkin(skin).orElse(null);
-                }
-                if (skinProps == null) {
-                    sender.sendMessage(Locale.PREFIX + ChatColor.DARK_RED + "no skin found....");
-                    return;
-                }
-
-                plugin.getSkinStorage().setSkinData(skinName, skinProps);
-
-                for (Player player : Bukkit.getOnlinePlayers()) {
-                    String pName = player.getName();
-                    plugin.getSkinStorage().setSkinName(pName, skinName); // set player to "whitespaced" name then reload skin
-                    plugin.getSkinsRestorerAPI().applySkin(new PlayerWrapper(player), skinProps);
-                }
-            } catch (SkinRequestException e) {
-                sender.sendMessage(e.getMessage());
-            }
-        });
+    public void onSetSkinAll(CommandSender sender, String skinUrl, @Optional SkinType skinType) {
+        onSetSkinAll(wrapCommandSender(sender), skinUrl, skinType);
     }
 
-    @SuppressWarnings("unused")
-    public enum PlayerOrSkin {
-        PLAYER,
-        SKIN,
+    @Override
+    public void reloadCustomHook() {
+        SkinApplierBukkit.setOptFileChecked(false);
     }
 
-    @SuppressWarnings("unused")
-    public enum SkinType {
-        STEVE,
-        SLIM,
+    @Override
+    public String getPlatformVersion() {
+        return plugin.getServer().getVersion();
+    }
+
+    @Override
+    public String getProxyMode() {
+        return String.valueOf(plugin.isBungeeEnabled());
     }
 }

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SrCommand.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/commands/SrCommand.java
@@ -33,6 +33,7 @@ import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.api.reflection.ReflectionUtil;
 import net.skinsrestorer.bukkit.SkinApplierBukkit;
 import net.skinsrestorer.bukkit.SkinsRestorer;
+import net.skinsrestorer.shared.commands.ISRCommand;
 import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.storage.Locale;
 import net.skinsrestorer.shared.utils.C;
@@ -52,10 +53,9 @@ import java.util.List;
 @RequiredArgsConstructor
 @CommandAlias("sr|skinsrestorer")
 @CommandPermission("%sr")
-public class SrCommand extends BaseCommand {
+public class SrCommand extends BaseCommand implements ISRCommand {
     private final SkinsRestorer plugin;
     private final SRLogger logger;
-    private SkinApplierBukkit skinApplierBukkit;
 
     @HelpCommand
     @Syntax(" [help]")

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/utils/WrapperBukkit.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/utils/WrapperBukkit.java
@@ -1,0 +1,71 @@
+/*
+ * SkinsRestorer
+ *
+ * Copyright (C) 2022 SkinsRestorer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ */
+package net.skinsrestorer.bukkit.utils;
+
+import net.skinsrestorer.api.PlayerWrapper;
+import net.skinsrestorer.api.interfaces.ISRCommandSender;
+import net.skinsrestorer.api.interfaces.ISRPlayer;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class WrapperBukkit {
+    public static ISRCommandSender wrapCommandSender(CommandSender sender) {
+        return new ISRCommandSender() {
+            @Override
+            public void sendMessage(String message) {
+                sender.sendMessage(message);
+            }
+
+            @Override
+            public String getName() {
+                return sender.getName();
+            }
+
+            @Override
+            public boolean hasPermission(String permission) {
+                return sender.hasPermission(permission);
+            }
+        };
+    }
+
+    public static ISRPlayer wrapPlayer(Player player) {
+        return new ISRPlayer() {
+            @Override
+            public PlayerWrapper getWrapper() {
+                return new PlayerWrapper(player);
+            }
+
+            @Override
+            public String getName() {
+                return player.getName();
+            }
+
+            @Override
+            public boolean hasPermission(String permission) {
+                return player.hasPermission(permission);
+            }
+
+            @Override
+            public void sendMessage(String message) {
+                player.sendMessage(message);
+            }
+        };
+    }
+}

--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/utils/WrapperBukkit.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/utils/WrapperBukkit.java
@@ -23,6 +23,7 @@ import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.interfaces.ISRCommandSender;
 import net.skinsrestorer.api.interfaces.ISRPlayer;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 
 public class WrapperBukkit {
@@ -41,6 +42,11 @@ public class WrapperBukkit {
             @Override
             public boolean hasPermission(String permission) {
                 return sender.hasPermission(permission);
+            }
+
+            @Override
+            public boolean isConsole() {
+                return sender instanceof ConsoleCommandSender;
             }
         };
     }

--- a/bungee/src/main/java/net/skinsrestorer/bungee/SkinsRestorer.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/SkinsRestorer.java
@@ -57,8 +57,10 @@ import org.inventivetalent.update.spiget.UpdateCallback;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.Collection;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Getter
 @SuppressWarnings("Duplicates")
@@ -139,7 +141,7 @@ public class SkinsRestorer extends Plugin implements ISRPlugin {
 
         this.skinCommand = new SkinCommand(this);
         manager.registerCommand(skinCommand);
-        manager.registerCommand(new SrCommand(this, srLogger));
+        manager.registerCommand(new SrCommand(this));
         manager.registerCommand(new GUICommand(this));
     }
 
@@ -182,6 +184,16 @@ public class SkinsRestorer extends Plugin implements ISRPlugin {
     @Override
     public InputStream getResource(String resource) {
         return getClass().getClassLoader().getResourceAsStream(resource);
+    }
+
+    @Override
+    public void runAsync(Runnable runnable) {
+        getProxy().getScheduler().runAsync(this, runnable);
+    }
+
+    @Override
+    public Collection<ISRPlayer> getOnlinePlayers() {
+        return getProxy().getPlayers().stream().map(WrapperBungee::wrapPlayer).collect(Collectors.toList());
     }
 
     private static class WrapperFactoryBungee extends WrapperFactory {

--- a/bungee/src/main/java/net/skinsrestorer/bungee/SkinsRestorer.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/SkinsRestorer.java
@@ -137,7 +137,7 @@ public class SkinsRestorer extends Plugin implements ISRPlugin {
 
         prepareACF(manager, srLogger);
 
-        this.skinCommand = new SkinCommand(this, srLogger);
+        this.skinCommand = new SkinCommand(this);
         manager.registerCommand(skinCommand);
         manager.registerCommand(new SrCommand(this, srLogger));
         manager.registerCommand(new GUICommand(this));

--- a/bungee/src/main/java/net/skinsrestorer/bungee/SkinsRestorer.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/SkinsRestorer.java
@@ -23,7 +23,6 @@ import co.aikar.commands.BungeeCommandManager;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import net.md_5.bungee.api.ProxyServer;
-import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.skinsrestorer.api.PlayerWrapper;
@@ -38,6 +37,7 @@ import net.skinsrestorer.bungee.commands.SrCommand;
 import net.skinsrestorer.bungee.listeners.LoginListener;
 import net.skinsrestorer.bungee.listeners.PluginMessageListener;
 import net.skinsrestorer.bungee.utils.BungeeConsoleImpl;
+import net.skinsrestorer.bungee.utils.WrapperBungee;
 import net.skinsrestorer.shared.interfaces.ISRPlugin;
 import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.storage.Locale;
@@ -186,26 +186,11 @@ public class SkinsRestorer extends Plugin implements ISRPlugin {
 
     private static class WrapperFactoryBungee extends WrapperFactory {
         @Override
-        public ISRPlayer wrap(Object playerInstance) {
+        public ISRPlayer wrapPlayer(Object playerInstance) {
             if (playerInstance instanceof ProxiedPlayer) {
                 ProxiedPlayer player = (ProxiedPlayer) playerInstance;
 
-                return new ISRPlayer() {
-                    @Override
-                    public PlayerWrapper getWrapper() {
-                        return new PlayerWrapper(playerInstance);
-                    }
-
-                    @Override
-                    public String getName() {
-                        return player.getName();
-                    }
-
-                    @Override
-                    public void sendMessage(String message) {
-                        player.sendMessage(TextComponent.fromLegacyText(message));
-                    }
-                };
+                return WrapperBungee.wrapPlayer(player);
             } else {
                 throw new IllegalArgumentException("Player instance is not valid!");
             }

--- a/bungee/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
@@ -28,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.skinsrestorer.api.PlayerWrapper;
+import net.skinsrestorer.api.SkinVariant;
 import net.skinsrestorer.bungee.SkinsRestorer;
 import net.skinsrestorer.shared.commands.ISkinCommand;
 
@@ -107,8 +108,8 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @CommandCompletion("@players @skin")
     @Description("%helpSkinSetOther")
     @Syntax("%SyntaxSkinSetOther")
-    public void onSkinSetOther(CommandSender sender, OnlinePlayer target, String skin, @Optional SkinType skinType) {
-        onSkinSetOther(wrapCommandSender(sender), wrapPlayer(target.getPlayer()), skin, skinType);
+    public void onSkinSetOther(CommandSender sender, OnlinePlayer target, String skin, @Optional SkinVariant skinVariant) {
+        onSkinSetOther(wrapCommandSender(sender), wrapPlayer(target.getPlayer()), skin, skinVariant);
     }
 
     @Subcommand("url")
@@ -116,8 +117,8 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @CommandCompletion("@skinUrl")
     @Description("%helpSkinSetUrl")
     @Syntax("%SyntaxSkinUrl")
-    public void onSkinSetUrl(ProxiedPlayer player, String url, @Optional SkinType skinType) {
-        onSkinSetUrl(wrapPlayer(player), url, skinType);
+    public void onSkinSetUrl(ProxiedPlayer player, String url, @Optional SkinVariant skinVariant) {
+        onSkinSetUrl(wrapPlayer(player), url, skinVariant);
     }
 
     @Override

--- a/bungee/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
@@ -21,42 +21,36 @@ package net.skinsrestorer.bungee.commands;
 
 import co.aikar.commands.BaseCommand;
 import co.aikar.commands.CommandHelp;
-import co.aikar.commands.InvalidCommandArgument;
 import co.aikar.commands.annotation.*;
 import co.aikar.commands.bungee.contexts.OnlinePlayer;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.skinsrestorer.api.PlayerWrapper;
-import net.skinsrestorer.api.exception.SkinRequestException;
-import net.skinsrestorer.api.interfaces.ISRCommandSender;
 import net.skinsrestorer.bungee.SkinsRestorer;
 import net.skinsrestorer.shared.commands.ISkinCommand;
-import net.skinsrestorer.shared.storage.Config;
-import net.skinsrestorer.shared.storage.CooldownStorage;
-import net.skinsrestorer.shared.storage.Locale;
-import net.skinsrestorer.shared.utils.C;
+
+import static net.skinsrestorer.bungee.utils.WrapperBungee.wrapCommandSender;
+import static net.skinsrestorer.bungee.utils.WrapperBungee.wrapPlayer;
 
 @RequiredArgsConstructor
 @CommandAlias("skin")
 @CommandPermission("%skin")
+@SuppressWarnings({"unused"})
 public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Getter
     private final SkinsRestorer plugin;
 
     @Default
-    @SuppressWarnings({"deprecation"})
     public void onDefault(CommandSender sender) {
-        onHelp(sender, getCurrentCommandManager().generateCommandHelp());
+        onDefault(wrapCommandSender(sender));
     }
 
     @Default
     @CommandPermission("%skinSet")
     @Description("%helpSkinSet")
     @Syntax("%SyntaxDefaultCommand")
-    @SuppressWarnings({"unused"})
     public void onSkinSetShort(ProxiedPlayer player, String skin) {
         onSkinSetOther(player, new OnlinePlayer(player), skin, null);
     }
@@ -64,19 +58,14 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @HelpCommand
     @Syntax(" [help]")
     public void onHelp(CommandSender sender, CommandHelp help) {
-        ISRCommandSender wrapped = wrap(sender);
-        if (Config.ENABLE_CUSTOM_HELP)
-            sendHelp(wrapped);
-        else
-            help.showHelp();
+        onHelp(wrapCommandSender(sender), help);
     }
 
     @Subcommand("clear")
     @CommandPermission("%skinClear")
     @Description("%helpSkinClear")
-    @SuppressWarnings({"unused"})
     public void onSkinClear(ProxiedPlayer player) {
-        onSkinClearOther(player, new OnlinePlayer(player));
+        onSkinClear(wrapPlayer(player));
     }
 
     @Subcommand("clear")
@@ -85,35 +74,14 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Syntax("%SyntaxSkinClearOther")
     @Description("%helpSkinClearOther")
     public void onSkinClearOther(CommandSender sender, @Single OnlinePlayer target) {
-        ISRCommandSender wrapped = wrap(sender);
-        runAsync(() -> {
-            if (!sender.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(sender.getName())) {
-                sender.sendMessage(TextComponent.fromLegacyText(Locale.SKIN_COOLDOWN.replace("%s", "" + CooldownStorage.getCooldown(sender.getName()))));
-                return;
-            }
-
-            final ProxiedPlayer player = target.getPlayer();
-            final String pName = player.getName();
-            final String skin = plugin.getSkinStorage().getDefaultSkinName(pName, true);
-
-            // remove users defined skin from database
-            plugin.getSkinStorage().removeSkin(pName);
-
-            if (setSkin(wrapped, new PlayerWrapper(player), skin, false, true, null)) {
-                if (sender == player)
-                    sender.sendMessage(TextComponent.fromLegacyText(Locale.SKIN_CLEAR_SUCCESS));
-                else
-                    sender.sendMessage(TextComponent.fromLegacyText(Locale.SKIN_CLEAR_ISSUER.replace("%player", pName)));
-            }
-        });
+        onSkinClearOther(wrapCommandSender(sender), wrapPlayer(target.getPlayer()));
     }
 
     @Subcommand("update")
     @CommandPermission("%skinUpdate")
     @Description("%helpSkinUpdate")
-    @SuppressWarnings({"unused"})
     public void onSkinUpdate(ProxiedPlayer player) {
-        onSkinUpdateOther(player, new OnlinePlayer(player));
+        onSkinUpdate(wrapPlayer(player));
     }
 
     @Subcommand("update")
@@ -122,45 +90,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Description("%helpSkinUpdateOther")
     @Syntax("%SyntaxSkinUpdateOther")
     public void onSkinUpdateOther(CommandSender sender, @Single OnlinePlayer target) {
-        ISRCommandSender wrapped = wrap(sender);
-        runAsync(() -> {
-            if (!sender.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(sender.getName())) {
-                sender.sendMessage(TextComponent.fromLegacyText(Locale.SKIN_COOLDOWN.replace("%s", "" + CooldownStorage.getCooldown(sender.getName()))));
-                return;
-            }
-
-            final ProxiedPlayer player = target.getPlayer();
-            java.util.Optional<String> skin = plugin.getSkinStorage().getSkinName(player.getName());
-
-            try {
-                if (skin.isPresent()) {
-                    //filter skinUrl
-                    if (skin.get().startsWith(" ")) {
-                        sender.sendMessage(TextComponent.fromLegacyText(Locale.ERROR_UPDATING_URL));
-                        return;
-                    }
-
-                    if (!plugin.getSkinStorage().updateSkinData(skin.get())) {
-                        sender.sendMessage(TextComponent.fromLegacyText(Locale.ERROR_UPDATING_SKIN));
-                        return;
-                    }
-
-                } else {
-                    // get DefaultSkin
-                    skin = java.util.Optional.of(plugin.getSkinStorage().getDefaultSkinName(player.getName(), true));
-                }
-            } catch (SkinRequestException e) {
-                sender.sendMessage(TextComponent.fromLegacyText(e.getMessage()));
-                return;
-            }
-
-            if (setSkin(wrapped, new PlayerWrapper(player), skin.get(), false, false, null)) {
-                if (sender == player)
-                    sender.sendMessage(TextComponent.fromLegacyText(Locale.SUCCESS_UPDATING_SKIN_OTHER.replace("%player", player.getName())));
-                else
-                    sender.sendMessage(TextComponent.fromLegacyText(Locale.SUCCESS_UPDATING_SKIN));
-            }
-        });
+        onSkinUpdateOther(wrapCommandSender(sender), wrapPlayer(target.getPlayer()));
     }
 
     @Subcommand("set")
@@ -169,10 +99,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Description("%helpSkinSet")
     @Syntax("%SyntaxSkinSet")
     public void onSkinSet(ProxiedPlayer player, String[] skin) {
-        if (skin.length == 0)
-            throw new InvalidCommandArgument(true);
-
-        onSkinSetOther(player, new OnlinePlayer(player), skin[0], null);
+        onSkinSet(wrapPlayer(player), skin);
     }
 
     @Subcommand("set")
@@ -181,20 +108,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Description("%helpSkinSetOther")
     @Syntax("%SyntaxSkinSetOther")
     public void onSkinSetOther(CommandSender sender, OnlinePlayer target, String skin, @Optional SkinType skinType) {
-        ISRCommandSender wrapped = wrap(sender);
-        runAsync(() -> {
-            final ProxiedPlayer player = target.getPlayer();
-            if (Config.PER_SKIN_PERMISSIONS && !wrapped.hasPermission("skinsrestorer.skin." + skin)) {
-                if (!wrapped.hasPermission("skinsrestorer.ownskin") && !wrapped.getName().equalsIgnoreCase(player.getName()) || !skin.equalsIgnoreCase(sender.getName())) {
-                    wrapped.sendMessage(Locale.PLAYER_HAS_NO_PERMISSION_SKIN);
-                    return;
-                }
-            }
-
-            if (setSkin(wrapped, new PlayerWrapper(player), skin, true, false, skinType) && (sender != player)) {
-                wrapped.sendMessage(Locale.ADMIN_SET_SKIN.replace("%player", player.getName()));
-            }
-        });
+        onSkinSetOther(wrapCommandSender(sender), wrapPlayer(target.getPlayer()), skin, skinType);
     }
 
     @Subcommand("url")
@@ -202,14 +116,8 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @CommandCompletion("@skinUrl")
     @Description("%helpSkinSetUrl")
     @Syntax("%SyntaxSkinUrl")
-    @SuppressWarnings({"unused"})
     public void onSkinSetUrl(ProxiedPlayer player, String url, @Optional SkinType skinType) {
-        if (!C.validUrl(url)) {
-            player.sendMessage(TextComponent.fromLegacyText(Locale.ERROR_INVALID_URLSKIN));
-            return;
-        }
-
-        onSkinSetOther(player, new OnlinePlayer(player), url, skinType);
+        onSkinSetUrl(wrapPlayer(player), url, skinType);
     }
 
     @Override
@@ -220,24 +128,5 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Override
     public void runAsync(Runnable runnable) {
         plugin.getProxy().getScheduler().runAsync(plugin, runnable);
-    }
-
-    private ISRCommandSender wrap(CommandSender sender) {
-        return new ISRCommandSender() {
-            @Override
-            public void sendMessage(String message) {
-                sender.sendMessage(TextComponent.fromLegacyText(message));
-            }
-
-            @Override
-            public String getName() {
-                return sender.getName();
-            }
-
-            @Override
-            public boolean hasPermission(String permission) {
-                return sender.hasPermission(permission);
-            }
-        };
     }
 }

--- a/bungee/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
@@ -27,8 +27,8 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.SkinVariant;
+import net.skinsrestorer.api.interfaces.ISRPlayer;
 import net.skinsrestorer.bungee.SkinsRestorer;
 import net.skinsrestorer.shared.commands.ISkinCommand;
 
@@ -122,7 +122,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     }
 
     @Override
-    public void clearSkin(PlayerWrapper player) {
-        plugin.getSkinsRestorerAPI().applySkin(player, emptySkin);
+    public void clearSkin(ISRPlayer player) {
+        plugin.getSkinsRestorerAPI().applySkin(player.getWrapper(), emptySkin);
     }
 }

--- a/bungee/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
@@ -124,9 +124,4 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     public void clearSkin(PlayerWrapper player) {
         plugin.getSkinsRestorerAPI().applySkin(player, emptySkin);
     }
-
-    @Override
-    public void runAsync(Runnable runnable) {
-        plugin.getProxy().getScheduler().runAsync(plugin, runnable);
-    }
 }

--- a/bungee/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
@@ -27,7 +27,6 @@ import co.aikar.commands.bungee.contexts.OnlinePlayer;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.skinsrestorer.api.PlayerWrapper;
@@ -39,7 +38,6 @@ import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.storage.CooldownStorage;
 import net.skinsrestorer.shared.storage.Locale;
 import net.skinsrestorer.shared.utils.C;
-import net.skinsrestorer.shared.utils.log.SRLogger;
 
 @RequiredArgsConstructor
 @CommandAlias("skin")
@@ -47,7 +45,6 @@ import net.skinsrestorer.shared.utils.log.SRLogger;
 public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Getter
     private final SkinsRestorer plugin;
-    private final SRLogger log;
 
     @Default
     @SuppressWarnings({"deprecation"})
@@ -89,7 +86,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Description("%helpSkinClearOther")
     public void onSkinClearOther(CommandSender sender, @Single OnlinePlayer target) {
         ISRCommandSender wrapped = wrap(sender);
-        ProxyServer.getInstance().getScheduler().runAsync(plugin, () -> {
+        runAsync(() -> {
             if (!sender.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(sender.getName())) {
                 sender.sendMessage(TextComponent.fromLegacyText(Locale.SKIN_COOLDOWN.replace("%s", "" + CooldownStorage.getCooldown(sender.getName()))));
                 return;
@@ -126,7 +123,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Syntax("%SyntaxSkinUpdateOther")
     public void onSkinUpdateOther(CommandSender sender, @Single OnlinePlayer target) {
         ISRCommandSender wrapped = wrap(sender);
-        ProxyServer.getInstance().getScheduler().runAsync(plugin, () -> {
+        runAsync(() -> {
             if (!sender.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(sender.getName())) {
                 sender.sendMessage(TextComponent.fromLegacyText(Locale.SKIN_COOLDOWN.replace("%s", "" + CooldownStorage.getCooldown(sender.getName()))));
                 return;
@@ -185,7 +182,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Syntax("%SyntaxSkinSetOther")
     public void onSkinSetOther(CommandSender sender, OnlinePlayer target, String skin, @Optional SkinType skinType) {
         ISRCommandSender wrapped = wrap(sender);
-        ProxyServer.getInstance().getScheduler().runAsync(plugin, () -> {
+        runAsync(() -> {
             final ProxiedPlayer player = target.getPlayer();
             if (Config.PER_SKIN_PERMISSIONS && !wrapped.hasPermission("skinsrestorer.skin." + skin)) {
                 if (!wrapped.hasPermission("skinsrestorer.ownskin") && !wrapped.getName().equalsIgnoreCase(player.getName()) || !skin.equalsIgnoreCase(sender.getName())) {
@@ -218,6 +215,11 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Override
     public void clearSkin(PlayerWrapper player) {
         plugin.getSkinsRestorerAPI().applySkin(player, emptySkin);
+    }
+
+    @Override
+    public void runAsync(Runnable runnable) {
+        plugin.getProxy().getScheduler().runAsync(plugin, runnable);
     }
 
     private ISRCommandSender wrap(CommandSender sender) {

--- a/bungee/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/commands/SkinCommand.java
@@ -34,6 +34,7 @@ import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.interfaces.ISRCommandSender;
 import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.bungee.SkinsRestorer;
+import net.skinsrestorer.shared.commands.ISkinCommand;
 import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.storage.CooldownStorage;
 import net.skinsrestorer.shared.storage.Locale;
@@ -45,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 @CommandAlias("skin")
 @CommandPermission("%skin")
-public class SkinCommand extends BaseCommand {
+public class SkinCommand extends BaseCommand implements ISkinCommand {
     private final SkinsRestorer plugin;
     private final SRLogger log;
 

--- a/bungee/src/main/java/net/skinsrestorer/bungee/commands/SrCommand.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/commands/SrCommand.java
@@ -26,8 +26,18 @@ import co.aikar.commands.bungee.contexts.OnlinePlayer;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.connection.InitialHandler;
+import net.md_5.bungee.connection.LoginResult;
+import net.skinsrestorer.api.interfaces.ISRPlayer;
+import net.skinsrestorer.api.property.GenericProperty;
+import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.bungee.SkinsRestorer;
 import net.skinsrestorer.shared.commands.ISRCommand;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static net.skinsrestorer.bungee.utils.WrapperBungee.wrapCommandSender;
 import static net.skinsrestorer.bungee.utils.WrapperBungee.wrapPlayer;
@@ -111,5 +121,19 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Override
     public String getProxyMode() {
         return "Bungee-Plugin";
+    }
+
+    @Override
+    public List<IProperty> getPropertiesOfPlayer(ISRPlayer player) {
+        LoginResult.Property[] props = ((InitialHandler) player.getWrapper().get(ProxiedPlayer.class)
+                .getPendingConnection()).getLoginProfile().getProperties();
+
+        if (props == null) {
+            return null;
+        } else {
+            return Arrays.stream(props)
+                    .map(property -> new GenericProperty(property.getName(), property.getValue(), property.getSignature()))
+                    .collect(Collectors.toList());
+        }
     }
 }

--- a/bungee/src/main/java/net/skinsrestorer/bungee/commands/SrCommand.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/commands/SrCommand.java
@@ -23,90 +23,40 @@ import co.aikar.commands.BaseCommand;
 import co.aikar.commands.CommandHelp;
 import co.aikar.commands.annotation.*;
 import co.aikar.commands.bungee.contexts.OnlinePlayer;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
-import net.md_5.bungee.api.chat.TextComponent;
-import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.connection.InitialHandler;
-import net.md_5.bungee.connection.LoginResult;
-import net.skinsrestorer.api.PlayerWrapper;
-import net.skinsrestorer.api.exception.SkinRequestException;
-import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.bungee.SkinsRestorer;
 import net.skinsrestorer.shared.commands.ISRCommand;
-import net.skinsrestorer.shared.storage.Config;
-import net.skinsrestorer.shared.storage.Locale;
-import net.skinsrestorer.shared.utils.C;
-import net.skinsrestorer.shared.utils.connections.ServiceChecker;
-import net.skinsrestorer.shared.utils.log.SRLogger;
 
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.List;
+import static net.skinsrestorer.bungee.utils.WrapperBungee.wrapCommandSender;
+import static net.skinsrestorer.bungee.utils.WrapperBungee.wrapPlayer;
 
 @RequiredArgsConstructor
 @CommandAlias("sr|skinsrestorer")
 @CommandPermission("%sr")
 public class SrCommand extends BaseCommand implements ISRCommand {
+    @Getter
     private final SkinsRestorer plugin;
-    private final SRLogger logger;
 
     @HelpCommand
     @Syntax(" [help]")
     public void onHelp(CommandSender sender, CommandHelp help) {
-        help.showHelp();
+        onHelp(wrapCommandSender(sender), help);
     }
 
     @Subcommand("reload")
     @CommandPermission("%srReload")
     @Description("%helpSrReload")
     public void onReload(CommandSender sender) {
-        Locale.load(plugin.getConfigPath(), logger);
-        Config.load(plugin.getConfigPath(), plugin.getResourceAsStream("config.yml"), logger);
-
-        plugin.prepareACF(plugin.getManager(), plugin.getSrLogger());
-
-        sender.sendMessage(TextComponent.fromLegacyText(Locale.RELOAD));
+        onReload(wrapCommandSender(sender));
     }
 
     @Subcommand("status")
     @CommandPermission("%srStatus")
     @Description("%helpSrStatus")
     public void onStatus(CommandSender sender) {
-        sender.sendMessage(TextComponent.fromLegacyText("§3----------------------------------------------"));
-        sender.sendMessage(TextComponent.fromLegacyText("§7Checking needed services for SR to work properly..."));
-
-        ProxyServer.getInstance().getScheduler().runAsync(plugin, () -> {
-            ServiceChecker checker = new ServiceChecker();
-            checker.setMojangAPI(plugin.getMojangAPI());
-            checker.checkServices();
-
-            ServiceChecker.ServiceCheckResponse response = checker.getResponse();
-            List<String> results = response.getResults();
-
-            if (Config.DEBUG || !(response.getWorkingUUID().get() >= 1) || !(response.getWorkingProfile().get() >= 1))
-                for (String result : results) {
-                    if (Config.DEBUG || result.contains("✘"))
-                        sender.sendMessage(TextComponent.fromLegacyText(result));
-                }
-            sender.sendMessage(TextComponent.fromLegacyText("§7Working UUID API count: §6 " + response.getWorkingUUID()));
-            sender.sendMessage(TextComponent.fromLegacyText("§7Working Profile API count: §6" + response.getWorkingProfile()));
-
-            if (response.getWorkingUUID().get() >= 1 && response.getWorkingProfile().get() >= 1)
-                sender.sendMessage(TextComponent.fromLegacyText("§aThe plugin currently is in a working state."));
-            else
-                sender.sendMessage(TextComponent.fromLegacyText("§cPlugin currently can't fetch new skins. \n Connection is likely blocked because of firewall. \n Please See http://skinsrestorer.net/firewall for more info"));
-
-            sender.sendMessage(TextComponent.fromLegacyText("§3----------------------------------------------"));
-            sender.sendMessage(TextComponent.fromLegacyText("§7SkinsRestorer §6v" + plugin.getVersion()));
-            sender.sendMessage(TextComponent.fromLegacyText("§7Server: §6" + plugin.getProxy().getVersion()));
-            sender.sendMessage(TextComponent.fromLegacyText("§7BungeeMode: §6Bungee-Plugin"));
-            sender.sendMessage(TextComponent.fromLegacyText("§7Finished checking services."));
-            sender.sendMessage(TextComponent.fromLegacyText("§3----------------------------------------------"));
-        });
+        onStatus(wrapCommandSender(sender));
     }
 
     @Subcommand("drop|remove")
@@ -115,14 +65,7 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("%helpSrDrop")
     @Syntax(" <player|skin> <target> [target2]")
     public void onDrop(CommandSender sender, PlayerOrSkin playerOrSkin, String[] targets) {
-        if (playerOrSkin == PlayerOrSkin.PLAYER)
-            for (String targetPlayer : targets)
-                plugin.getSkinStorage().removeSkin(targetPlayer);
-        else
-            for (String targetSkin : targets)
-                plugin.getSkinStorage().removeSkinData(targetSkin);
-        String targetList = Arrays.toString(targets).substring(1, Arrays.toString(targets).length() - 1);
-        sender.sendMessage(TextComponent.fromLegacyText(Locale.DATA_DROPPED.replace("%playerOrSkin", playerOrSkin.toString()).replace("%targets", targetList)));
+        onDrop(wrapCommandSender(sender), playerOrSkin, targets);
     }
 
     @Subcommand("props")
@@ -131,32 +74,7 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("%helpSrProps")
     @Syntax(" <target>")
     public void onProps(CommandSender sender, @Single OnlinePlayer target) {
-        LoginResult.Property prop = ((InitialHandler) target.getPlayer().getPendingConnection()).getLoginProfile().getProperties()[0];
-
-        if (prop == null) {
-            sender.sendMessage(TextComponent.fromLegacyText(Locale.NO_SKIN_DATA));
-            return;
-        }
-
-        byte[] decoded = Base64.getDecoder().decode(prop.getValue());
-
-        String decodedString = new String(decoded);
-        JsonObject jsonObject = JsonParser.parseString(decodedString).getAsJsonObject();
-        String decodedSkin = jsonObject.getAsJsonObject().get("textures").getAsJsonObject().get("SKIN").getAsJsonObject().get("url").toString();
-        long timestamp = Long.parseLong(jsonObject.getAsJsonObject().get("timestamp").toString());
-        String requestDate = new java.text.SimpleDateFormat("MM/dd/yyyy HH:mm:ss").format(new java.util.Date(timestamp));
-
-        sender.sendMessage(TextComponent.fromLegacyText("§aRequest time: §e" + requestDate));
-        sender.sendMessage(TextComponent.fromLegacyText("§aprofileId: §e" + jsonObject.getAsJsonObject().get("profileId").toString()));
-        sender.sendMessage(TextComponent.fromLegacyText("§aName: §e" + jsonObject.getAsJsonObject().get("profileName").toString()));
-        sender.sendMessage(TextComponent.fromLegacyText("§aSkinTexture: §e" + decodedSkin.substring(1, decodedSkin.length() - 1)));
-        sender.sendMessage(TextComponent.fromLegacyText("§cMore info in console!"));
-
-        // Console
-        logger.info("§aName: §8" + prop.getName());
-        logger.info("§aValue : §8" + prop.getValue());
-        logger.info("§aSignature : §8" + prop.getSignature());
-        logger.info("§aValue Decoded: §e" + Arrays.toString(decoded));
+        onProps(wrapCommandSender(sender), wrapPlayer(target.getPlayer()));
     }
 
     @Subcommand("applyskin")
@@ -165,18 +83,7 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("%helpSrApplySkin")
     @Syntax(" <target>")
     public void onApplySkin(CommandSender sender, @Single OnlinePlayer target) {
-        ProxyServer.getInstance().getScheduler().runAsync(plugin, () -> {
-            try {
-                final ProxiedPlayer player = target.getPlayer();
-                final String name = player.getName();
-                final String skin = plugin.getSkinStorage().getDefaultSkinName(name);
-
-                plugin.getSkinsRestorerAPI().applySkin(new PlayerWrapper(player), skin);
-                sender.sendMessage(TextComponent.fromLegacyText("success: player skin has been refreshed!"));
-            } catch (Exception ignored) {
-                sender.sendMessage(TextComponent.fromLegacyText("ERROR: player skin could NOT be refreshed!"));
-            }
-        });
+        onApplySkin(wrapCommandSender(sender), wrapPlayer(target.getPlayer()));
     }
 
     @Subcommand("createcustom")
@@ -185,19 +92,7 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("%helpSrCreateCustom")
     @Syntax(" <skinName> <skinUrl> [steve/slim]")
     public void onCreateCustom(CommandSender sender, String skinName, String skinUrl, @Optional SkinType skinType) {
-        ProxyServer.getInstance().getScheduler().runAsync(plugin, () -> {
-            try {
-                if (C.validUrl(skinUrl)) {
-                    plugin.getSkinStorage().setSkinData(skinName, plugin.getMineSkinAPI().genSkin(skinUrl, String.valueOf(skinType), null),
-                            System.currentTimeMillis() + (100L * 365 * 24 * 60 * 60 * 1000)); // "generate" and save skin for 100 years
-                    sender.sendMessage(TextComponent.fromLegacyText(Locale.SUCCESS_CREATE_SKIN.replace("%skin", skinName)));
-                } else {
-                    sender.sendMessage(TextComponent.fromLegacyText(Locale.ERROR_INVALID_URLSKIN));
-                }
-            } catch (SkinRequestException e) {
-                sender.sendMessage(TextComponent.fromLegacyText(e.getMessage()));
-            }
-        });
+        onCreateCustom(wrapCommandSender(sender), skinName, skinUrl, skinType);
     }
 
     @Subcommand("setskinall")
@@ -205,46 +100,16 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("Set the skin to evey player")
     @Syntax(" <Skin / Url> [steve/slim]")
     public void onSetSkinAll(CommandSender sender, String skin, @Optional SkinType skinType) {
-        ProxyServer.getInstance().getScheduler().runAsync(plugin, () -> {
-            if (sender != ProxyServer.getInstance().getConsole()) {
-                sender.sendMessage(TextComponent.fromLegacyText(Locale.PREFIX + "§4Only console may execute this command!"));
-                return;
-            }
-
-            String skinName = " ·setSkinAll";
-            try {
-                IProperty skinProps = null;
-                if (C.validUrl(skin)) {
-                    skinProps = plugin.getMineSkinAPI().genSkin(skin, String.valueOf(skinType), null);
-                } else {
-                    skinProps = plugin.getMojangAPI().getSkin(skin).orElse(null);
-                }
-                if (skinProps == null) {
-                    sender.sendMessage(TextComponent.fromLegacyText(Locale.PREFIX + ("§4no skin found....")));
-                    return;
-                }
-
-                plugin.getSkinStorage().setSkinData(skinName, skinProps);
-                for (ProxiedPlayer player : ProxyServer.getInstance().getPlayers()) {
-                    String pName = player.getName();
-                    plugin.getSkinStorage().setSkinName(pName, skinName); // set player to "whitespaced" name then reload skin
-                    plugin.getSkinsRestorerAPI().applySkin(new PlayerWrapper(player), skinProps);
-                }
-            } catch (SkinRequestException e) {
-                sender.sendMessage(TextComponent.fromLegacyText(e.getMessage()));
-            }
-        });
+        onSetSkinAll(wrapCommandSender(sender), skin, skinType);
     }
 
-    @SuppressWarnings("unused")
-    public enum PlayerOrSkin {
-        PLAYER,
-        SKIN,
+    @Override
+    public String getPlatformVersion() {
+        return plugin.getProxy().getVersion();
     }
 
-    @SuppressWarnings("unused")
-    public enum SkinType {
-        STEVE,
-        SLIM,
+    @Override
+    public String getProxyMode() {
+        return "Bungee-Plugin";
     }
 }

--- a/bungee/src/main/java/net/skinsrestorer/bungee/commands/SrCommand.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/commands/SrCommand.java
@@ -36,6 +36,7 @@ import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.bungee.SkinsRestorer;
+import net.skinsrestorer.shared.commands.ISRCommand;
 import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.storage.Locale;
 import net.skinsrestorer.shared.utils.C;
@@ -49,7 +50,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @CommandAlias("sr|skinsrestorer")
 @CommandPermission("%sr")
-public class SrCommand extends BaseCommand {
+public class SrCommand extends BaseCommand implements ISRCommand {
     private final SkinsRestorer plugin;
     private final SRLogger logger;
 

--- a/bungee/src/main/java/net/skinsrestorer/bungee/commands/SrCommand.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/commands/SrCommand.java
@@ -29,6 +29,7 @@ import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.connection.InitialHandler;
 import net.md_5.bungee.connection.LoginResult;
+import net.skinsrestorer.api.SkinVariant;
 import net.skinsrestorer.api.interfaces.ISRPlayer;
 import net.skinsrestorer.api.property.GenericProperty;
 import net.skinsrestorer.api.property.IProperty;
@@ -100,17 +101,17 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @CommandPermission("%srCreateCustom")
     @CommandCompletion("@skinName @skinUrl")
     @Description("%helpSrCreateCustom")
-    @Syntax(" <skinName> <skinUrl> [steve/slim]")
-    public void onCreateCustom(CommandSender sender, String skinName, String skinUrl, @Optional SkinType skinType) {
-        onCreateCustom(wrapCommandSender(sender), skinName, skinUrl, skinType);
+    @Syntax(" <skinName> <skinUrl> [classic/slim]")
+    public void onCreateCustom(CommandSender sender, String skinName, String skinUrl, @Optional SkinVariant skinVariant) {
+        onCreateCustom(wrapCommandSender(sender), skinName, skinUrl, skinVariant);
     }
 
     @Subcommand("setskinall")
     @CommandCompletion("@Skin")
     @Description("Set the skin to evey player")
-    @Syntax(" <Skin / Url> [steve/slim]")
-    public void onSetSkinAll(CommandSender sender, String skin, @Optional SkinType skinType) {
-        onSetSkinAll(wrapCommandSender(sender), skin, skinType);
+    @Syntax(" <Skin / Url> [classic/slim]")
+    public void onSetSkinAll(CommandSender sender, String skin, @Optional SkinVariant skinVariant) {
+        onSetSkinAll(wrapCommandSender(sender), skin, skinVariant);
     }
 
     @Override

--- a/bungee/src/main/java/net/skinsrestorer/bungee/utils/WrapperBungee.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/utils/WrapperBungee.java
@@ -1,0 +1,72 @@
+/*
+ * SkinsRestorer
+ *
+ * Copyright (C) 2022 SkinsRestorer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ */
+package net.skinsrestorer.bungee.utils;
+
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.skinsrestorer.api.PlayerWrapper;
+import net.skinsrestorer.api.interfaces.ISRCommandSender;
+import net.skinsrestorer.api.interfaces.ISRPlayer;
+
+public class WrapperBungee {
+    public static ISRCommandSender wrapCommandSender(CommandSender sender) {
+        return new ISRCommandSender() {
+            @Override
+            public void sendMessage(String message) {
+                sender.sendMessage(TextComponent.fromLegacyText(message));
+            }
+
+            @Override
+            public String getName() {
+                return sender.getName();
+            }
+
+            @Override
+            public boolean hasPermission(String permission) {
+                return sender.hasPermission(permission);
+            }
+        };
+    }
+
+    public static ISRPlayer wrapPlayer(ProxiedPlayer player) {
+        return new ISRPlayer() {
+            @Override
+            public PlayerWrapper getWrapper() {
+                return new PlayerWrapper(player);
+            }
+
+            @Override
+            public String getName() {
+                return player.getName();
+            }
+
+            @Override
+            public void sendMessage(String message) {
+                player.sendMessage(TextComponent.fromLegacyText(message));
+            }
+
+            @Override
+            public boolean hasPermission(String permission) {
+                return player.hasPermission(permission);
+            }
+        };
+    }
+}

--- a/bungee/src/main/java/net/skinsrestorer/bungee/utils/WrapperBungee.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/utils/WrapperBungee.java
@@ -22,6 +22,7 @@ package net.skinsrestorer.bungee.utils;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.command.ConsoleCommandSender;
 import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.interfaces.ISRCommandSender;
 import net.skinsrestorer.api.interfaces.ISRPlayer;
@@ -42,6 +43,11 @@ public class WrapperBungee {
             @Override
             public boolean hasPermission(String permission) {
                 return sender.hasPermission(permission);
+            }
+
+            @Override
+            public boolean isConsole() {
+                return sender instanceof ConsoleCommandSender;
             }
         };
     }

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISRCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISRCommand.java
@@ -19,5 +19,228 @@
  */
 package net.skinsrestorer.shared.commands;
 
+import co.aikar.commands.CommandHelp;
+import co.aikar.commands.annotation.Optional;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.mojang.authlib.properties.PropertyMap;
+import net.skinsrestorer.api.SkinsRestorerAPI;
+import net.skinsrestorer.api.exception.SkinRequestException;
+import net.skinsrestorer.api.interfaces.ISRCommandSender;
+import net.skinsrestorer.api.interfaces.ISRPlayer;
+import net.skinsrestorer.api.property.IProperty;
+import net.skinsrestorer.api.reflection.ReflectionUtil;
+import net.skinsrestorer.shared.interfaces.ISRPlugin;
+import net.skinsrestorer.shared.storage.Config;
+import net.skinsrestorer.shared.storage.Locale;
+import net.skinsrestorer.shared.utils.C;
+import net.skinsrestorer.shared.utils.connections.ServiceChecker;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.List;
+
 public interface ISRCommand {
+    default void onHelp(ISRCommandSender sender, CommandHelp help) {
+        help.showHelp();
+    }
+
+    default void reloadCustomHook() {
+    }
+
+    default void onReload(ISRCommandSender sender) {
+        ISRPlugin plugin = getPlugin();
+        reloadCustomHook();
+        Locale.load(plugin.getDataFolder(), plugin.getSrLogger());
+        Config.load(plugin.getDataFolder(), plugin.getResource("config.yml"), plugin.getSrLogger());
+
+        plugin.prepareACF(plugin.getManager(), plugin.getSrLogger());
+
+        sender.sendMessage(Locale.RELOAD);
+    }
+
+    default void onStatus(ISRCommandSender sender) {
+        ISRPlugin plugin = getPlugin();
+        plugin.runAsync(() -> {
+            sender.sendMessage("§3----------------------------------------------");
+            sender.sendMessage("§7Checking needed services for SR to work properly...");
+
+            ServiceChecker checker = new ServiceChecker();
+            checker.setMojangAPI(plugin.getMojangAPI());
+            checker.checkServices();
+
+            ServiceChecker.ServiceCheckResponse response = checker.getResponse();
+            List<String> results = response.getResults();
+
+            if (Config.DEBUG || !(response.getWorkingUUID().get() >= 1) || !(response.getWorkingProfile().get() >= 1))
+                for (String result : results) {
+                    if (Config.DEBUG || result.contains("✘"))
+                        sender.sendMessage(result);
+                }
+
+            sender.sendMessage("§7Working UUID API count: §6" + response.getWorkingUUID());
+            sender.sendMessage("§7Working Profile API count: §6" + response.getWorkingProfile());
+
+            if (response.getWorkingUUID().get() >= 1 && response.getWorkingProfile().get() >= 1)
+                sender.sendMessage("§aThe plugin currently is in a working state.");
+            else
+                sender.sendMessage("§cPlugin currently can't fetch new skins. \n Connection is likely blocked because of firewall. \n Please See http://skinsrestorer.net/firewall for more info");
+            sender.sendMessage("§3----------------------------------------------");
+            sender.sendMessage("§7SkinsRestorer §6v" + plugin.getVersion());
+            sender.sendMessage("§7Server: §6" + getPlatformVersion());
+            sender.sendMessage("§7ProxyMode: §6" + getProxyMode());
+            sender.sendMessage("§7Finished checking services.");
+            sender.sendMessage("§3----------------------------------------------");
+        });
+    }
+
+    default void onDrop(ISRCommandSender sender, PlayerOrSkin playerOrSkin, String[] targets) {
+        ISRPlugin plugin = getPlugin();
+        plugin.runAsync(() -> {
+            if (playerOrSkin == PlayerOrSkin.PLAYER)
+                for (String targetPlayer : targets)
+                    plugin.getSkinStorage().removeSkin(targetPlayer);
+            else
+                for (String targetSkin : targets)
+                    plugin.getSkinStorage().removeSkinData(targetSkin);
+
+            String targetList = Arrays.toString(targets).substring(1, Arrays.toString(targets).length() - 1);
+            sender.sendMessage(Locale.DATA_DROPPED.replace("%playerOrSkin", playerOrSkin.toString()).replace("%targets", targetList));
+        });
+    }
+
+    default void onProps(ISRCommandSender sender, ISRPlayer target) {
+        ISRPlugin plugin = getPlugin();
+        plugin.runAsync(() -> {
+            try {
+                PropertyMap propertyMap = plugin.getSkinApplierBukkit().getGameProfile(target.getWrapper()).getProperties(); // TODO: make not platform specific
+                Collection<?> props = (Collection<?>) ReflectionUtil.invokeMethod(propertyMap.getClass(), propertyMap, "get",
+                        new Class<?>[]{Object.class}, "textures");
+
+                if (props == null || props.isEmpty()) {
+                    sender.sendMessage(Locale.NO_SKIN_DATA);
+                    return;
+                }
+
+                for (Object prop : props) {
+                    String name = (String) ReflectionUtil.invokeMethod(prop, "getName");
+                    String value = (String) ReflectionUtil.invokeMethod(prop, "getValue");
+                    String signature = (String) ReflectionUtil.invokeMethod(prop, "getSignature");
+
+                    byte[] decoded = Base64.getDecoder().decode(value);
+                    String decodedString = new String(decoded);
+                    JsonObject jsonObject = JsonParser.parseString(decodedString).getAsJsonObject();
+                    String decodedSkin = jsonObject.getAsJsonObject().get("textures").getAsJsonObject().get("SKIN").getAsJsonObject().get("url").toString();
+                    long timestamp = Long.parseLong(jsonObject.getAsJsonObject().get("timestamp").toString());
+                    String requestDate = new java.text.SimpleDateFormat("MM/dd/yyyy HH:mm:ss").format(new java.util.Date(timestamp));
+
+                    sender.sendMessage("§aRequest time: §e" + requestDate);
+                    sender.sendMessage("§aProfileId: §e" + jsonObject.getAsJsonObject().get("profileId").toString());
+                    sender.sendMessage("§aName: §e" + jsonObject.getAsJsonObject().get("profileName").toString());
+                    sender.sendMessage("§aSkinTexture: §e" + decodedSkin.substring(1, decodedSkin.length() - 1));
+                    sender.sendMessage("§cMore info in console!");
+
+                    // Console
+                    plugin.getSrLogger().info("§aName: §8" + name);
+                    plugin.getSrLogger().info("§aValue : §8" + value);
+                    plugin.getSrLogger().info("§aSignature : §8" + signature);
+                    plugin.getSrLogger().info("§aValue Decoded: §e" + Arrays.toString(decoded));
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+                sender.sendMessage(Locale.NO_SKIN_DATA);
+            }
+        });
+    }
+
+    default void onApplySkin(ISRCommandSender sender, ISRPlayer target) {
+        ISRPlugin plugin = getPlugin();
+        plugin.runAsync(() -> {
+            try {
+
+                final String name = sender.getName();
+                final String skin = plugin.getSkinStorage().getDefaultSkinName(name);
+
+                if (C.validUrl(skin)) {
+                    SkinsRestorerAPI.getApi().applySkin(target.getWrapper(), SkinsRestorerAPI.getApi().genSkinUrl(skin, null));
+                } else {
+                    SkinsRestorerAPI.getApi().applySkin(target.getWrapper(), skin);
+                }
+                sender.sendMessage("success: player skin has been refreshed!");
+            } catch (Exception ignored) {
+                sender.sendMessage("ERROR: player skin could NOT be refreshed!");
+            }
+        });
+    }
+
+    default void onCreateCustom(ISRCommandSender sender, String name, String skinUrl, SkinType skinType) {
+        ISRPlugin plugin = getPlugin();
+        plugin.runAsync(() -> {
+            try {
+                if (C.validUrl(skinUrl)) {
+                    plugin.getSkinStorage().setSkinData(name, SkinsRestorerAPI.getApi().genSkinUrl(skinUrl, String.valueOf(skinType)),
+                            System.currentTimeMillis() + Duration.of(100, ChronoUnit.YEARS).toMillis()); // "generate" and save skin for 100 years
+                    sender.sendMessage(Locale.SUCCESS_CREATE_SKIN.replace("%skin", name));
+                } else {
+                    sender.sendMessage(Locale.ERROR_INVALID_URLSKIN);
+                }
+            } catch (SkinRequestException e) {
+                sender.sendMessage(e.getMessage());
+            }
+        });
+    }
+
+
+    default void onSetSkinAll(ISRCommandSender sender, String skin, @Optional SkinType skinType) {
+        ISRPlugin plugin = getPlugin();
+        plugin.runAsync(() -> {
+            if (!(sender instanceof ConsoleCommandSender)) { //only make console perform this command
+                sender.sendMessage(Locale.PREFIX + "Only console may execute this command!"); // TODO: add chat color
+                return;
+            }
+
+            String skinName = " ·setSkinAll";
+            try {
+                IProperty skinProps;
+                if (C.validUrl(skin)) {
+                    skinProps = SkinsRestorerAPI.getApi().genSkinUrl(skin, String.valueOf(skinType));
+                } else {
+                    skinProps = plugin.getMojangAPI().getSkin(skin).orElse(null);
+                }
+                if (skinProps == null) {
+                    sender.sendMessage(Locale.PREFIX + "no skin found...."); // TODO: add chat color
+                    return;
+                }
+
+                plugin.getSkinStorage().setSkinData(skinName, skinProps);
+
+                for (ISRPlayer player : plugin.getOnlinePlayers()) {
+                    String pName = player.getName();
+                    plugin.getSkinStorage().setSkinName(pName, skinName); // set player to "whitespaced" name then reload skin
+                    SkinsRestorerAPI.getApi().applySkin(player.getWrapper(), skinProps);
+                }
+            } catch (SkinRequestException e) {
+                sender.sendMessage(e.getMessage());
+            }
+        });
+    }
+
+    String getPlatformVersion();
+
+    String getProxyMode();
+
+    ISRPlugin getPlugin();
+
+    enum PlayerOrSkin {
+        PLAYER,
+        SKIN,
+    }
+
+    enum SkinType {
+        STEVE,
+        SLIM,
+    }
 }

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISRCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISRCommand.java
@@ -20,9 +20,9 @@
 package net.skinsrestorer.shared.commands;
 
 import co.aikar.commands.CommandHelp;
-import co.aikar.commands.annotation.Optional;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import net.skinsrestorer.api.SkinVariant;
 import net.skinsrestorer.api.SkinsRestorerAPI;
 import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.interfaces.ISRCommandSender;
@@ -34,12 +34,10 @@ import net.skinsrestorer.shared.storage.Locale;
 import net.skinsrestorer.shared.utils.C;
 import net.skinsrestorer.shared.utils.connections.ServiceChecker;
 
+import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 public interface ISRCommand {
     @SuppressWarnings("unused")
@@ -141,9 +139,7 @@ public interface ISRCommand {
                 JsonObject jsonObject = JsonParser.parseString(decodedString).getAsJsonObject();
                 String decodedSkin = jsonObject.getAsJsonObject().get("textures").getAsJsonObject().get("SKIN").getAsJsonObject().get("url").toString();
                 long timestamp = Long.parseLong(jsonObject.getAsJsonObject().get("timestamp").toString());
-                String requestDate = new java.text.SimpleDateFormat("MM/dd/yyyy HH:mm:ss").format(new java.util.Date(timestamp));
-
-
+                String requestDate = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss").format(new Date(timestamp));
 
                 sender.sendMessage("§aRequest time: §e" + requestDate);
                 sender.sendMessage("§aProfileId: §e" + jsonObject.getAsJsonObject().get("profileId").toString());
@@ -182,12 +178,12 @@ public interface ISRCommand {
         });
     }
 
-    default void onCreateCustom(ISRCommandSender sender, String name, String skinUrl, SkinType skinType) {
+    default void onCreateCustom(ISRCommandSender sender, String name, String skinUrl, SkinVariant skinVariant) {
         ISRPlugin plugin = getPlugin();
         plugin.runAsync(() -> {
             try {
                 if (C.validUrl(skinUrl)) {
-                    plugin.getSkinStorage().setSkinData(name, SkinsRestorerAPI.getApi().genSkinUrl(skinUrl, String.valueOf(skinType)),
+                    plugin.getSkinStorage().setSkinData(name, SkinsRestorerAPI.getApi().genSkinUrl(skinUrl, skinVariant),
                             System.currentTimeMillis() + Duration.of(100, ChronoUnit.YEARS).toMillis()); // "generate" and save skin for 100 years
                     sender.sendMessage(Locale.SUCCESS_CREATE_SKIN.replace("%skin", name));
                 } else {
@@ -199,7 +195,7 @@ public interface ISRCommand {
         });
     }
 
-    default void onSetSkinAll(ISRCommandSender sender, String skin, @Optional SkinType skinType) {
+    default void onSetSkinAll(ISRCommandSender sender, String skin, SkinVariant skinVariant) {
         ISRPlugin plugin = getPlugin();
         plugin.runAsync(() -> {
             if (!sender.isConsole()) { // Only make console perform this command
@@ -211,7 +207,7 @@ public interface ISRCommand {
             try {
                 IProperty skinProps;
                 if (C.validUrl(skin)) {
-                    skinProps = SkinsRestorerAPI.getApi().genSkinUrl(skin, String.valueOf(skinType));
+                    skinProps = SkinsRestorerAPI.getApi().genSkinUrl(skin, skinVariant);
                 } else {
                     skinProps = plugin.getMojangAPI().getSkin(skin).orElse(null);
                 }

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISRCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISRCommand.java
@@ -1,3 +1,22 @@
+/*
+ * SkinsRestorer
+ *
+ * Copyright (C) 2022 SkinsRestorer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ */
 package net.skinsrestorer.shared.commands;
 
 public interface ISRCommand {

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISRCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISRCommand.java
@@ -199,7 +199,7 @@ public interface ISRCommand {
         ISRPlugin plugin = getPlugin();
         plugin.runAsync(() -> {
             if (!sender.isConsole()) { // Only make console perform this command
-                sender.sendMessage(Locale.PREFIX + "Only console may execute this command!"); // TODO: add chat color
+                sender.sendMessage(Locale.PREFIX + "§4Only console may execute this command!");
                 return;
             }
 
@@ -212,7 +212,7 @@ public interface ISRCommand {
                     skinProps = plugin.getMojangAPI().getSkin(skin).orElse(null);
                 }
                 if (skinProps == null) {
-                    sender.sendMessage(Locale.PREFIX + "no skin found...."); // TODO: add chat color
+                    sender.sendMessage(Locale.PREFIX + "§4no skin found....");
                     return;
                 }
 

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISRCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISRCommand.java
@@ -72,20 +72,19 @@ public interface ISRCommand {
             ServiceChecker.ServiceCheckResponse response = checker.getResponse();
             List<String> results = response.getResults();
 
-            final int workingUUIDINT = response.getWorkingUUID().get();
-            final int workingProfileINT = response.getWorkingProfile().get();
+            final int workingUUIDCount = response.getWorkingUUID().get();
+            final int workingProfileCount = response.getWorkingProfile().get();
 
             // only print per API results if in a not working state
-            if (Config.DEBUG || workingUUIDINT == 0 || workingProfileINT == 0)
-                for (String result : results) {
+            if (Config.DEBUG || workingUUIDCount == 0 || workingProfileCount == 0)
+                for (String result : results)
                     if (Config.DEBUG || result.contains("✘"))
                         sender.sendMessage(result);
-                }
 
-            sender.sendMessage("§7Working UUID API count: §6" + workingUUIDINT);
-            sender.sendMessage("§7Working Profile API count: §6" + workingProfileINT);
+            sender.sendMessage("§7Working UUID API count: §6" + workingUUIDCount);
+            sender.sendMessage("§7Working Profile API count: §6" + workingProfileCount);
 
-            if (workingUUIDINT != 0 && workingProfileINT != 0)
+            if (workingUUIDCount != 0 && workingProfileCount != 0)
                 sender.sendMessage("§aThe plugin currently is in a working state.");
             else
                 sender.sendMessage("§cPlugin currently can't fetch new skins. \n Connection is likely blocked because of firewall. \n Please See http://skinsrestorer.net/firewall for more info");
@@ -101,15 +100,16 @@ public interface ISRCommand {
     default void onDrop(ISRCommandSender sender, PlayerOrSkin playerOrSkin, String[] targets) {
         ISRPlugin plugin = getPlugin();
         plugin.runAsync(() -> {
-            if (playerOrSkin == PlayerOrSkin.PLAYER)
-                for (String targetPlayer : targets)
-                    plugin.getSkinStorage().removeSkin(targetPlayer);
-            else
-                for (String targetSkin : targets)
-                    plugin.getSkinStorage().removeSkinData(targetSkin);
+            switch (playerOrSkin) {
+                case PLAYER:
+                    for (String targetPlayer : targets) plugin.getSkinStorage().removeSkin(targetPlayer);
+                    break;
+                case SKIN:
+                    for (String targetSkin : targets) plugin.getSkinStorage().removeSkinData(targetSkin);
+                    break;
+            }
 
-            String targetList = Arrays.toString(targets).substring(1, Arrays.toString(targets).length() - 1);
-            sender.sendMessage(String.format(Locale.DATA_DROPPED, playerOrSkin.toString(), targetList));
+            sender.sendMessage(String.format(Locale.DATA_DROPPED, playerOrSkin, String.join(", ", targets)));
         });
     }
 

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISRCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISRCommand.java
@@ -72,16 +72,20 @@ public interface ISRCommand {
             ServiceChecker.ServiceCheckResponse response = checker.getResponse();
             List<String> results = response.getResults();
 
-            if (Config.DEBUG || !(response.getWorkingUUID().get() >= 1) || !(response.getWorkingProfile().get() >= 1))
+            final int workingUUIDINT = response.getWorkingUUID().get();
+            final int workingProfileINT = response.getWorkingProfile().get();
+
+            // only print per API results if in a not working state
+            if (Config.DEBUG || workingUUIDINT == 0 || workingProfileINT == 0)
                 for (String result : results) {
                     if (Config.DEBUG || result.contains("✘"))
                         sender.sendMessage(result);
                 }
 
-            sender.sendMessage("§7Working UUID API count: §6" + response.getWorkingUUID());
-            sender.sendMessage("§7Working Profile API count: §6" + response.getWorkingProfile());
+            sender.sendMessage("§7Working UUID API count: §6" + workingUUIDINT);
+            sender.sendMessage("§7Working Profile API count: §6" + workingProfileINT);
 
-            if (response.getWorkingUUID().get() >= 1 && response.getWorkingProfile().get() >= 1)
+            if (workingUUIDINT != 0 && workingProfileINT != 0)
                 sender.sendMessage("§aThe plugin currently is in a working state.");
             else
                 sender.sendMessage("§cPlugin currently can't fetch new skins. \n Connection is likely blocked because of firewall. \n Please See http://skinsrestorer.net/firewall for more info");
@@ -105,7 +109,7 @@ public interface ISRCommand {
                     plugin.getSkinStorage().removeSkinData(targetSkin);
 
             String targetList = Arrays.toString(targets).substring(1, Arrays.toString(targets).length() - 1);
-            sender.sendMessage(Locale.DATA_DROPPED.replace("%playerOrSkin", playerOrSkin.toString()).replace("%targets", targetList));
+            sender.sendMessage(String.format(Locale.DATA_DROPPED, playerOrSkin.toString(), targetList));
         });
     }
 
@@ -177,7 +181,7 @@ public interface ISRCommand {
                 if (C.validUrl(skinUrl)) {
                     plugin.getSkinStorage().setSkinData(name, SkinsRestorerAPI.getApi().genSkinUrl(skinUrl, String.valueOf(skinType)),
                             System.currentTimeMillis() + Duration.of(100, ChronoUnit.YEARS).toMillis()); // "generate" and save skin for 100 years
-                    sender.sendMessage(Locale.SUCCESS_CREATE_SKIN.replace("%skin", name));
+                    sender.sendMessage(String.format(Locale.SUCCESS_CREATE_SKIN, name));
                 } else {
                     sender.sendMessage(Locale.ERROR_INVALID_URLSKIN);
                 }
@@ -229,11 +233,13 @@ public interface ISRCommand {
 
     List<IProperty> getPropertiesOfPlayer(ISRPlayer player);
 
+    @SuppressWarnings("unused")
     enum PlayerOrSkin {
         PLAYER,
         SKIN,
     }
 
+    @SuppressWarnings("unused")
     enum SkinType {
         STEVE,
         SLIM,

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISRCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISRCommand.java
@@ -1,0 +1,4 @@
+package net.skinsrestorer.shared.commands;
+
+public interface ISRCommand {
+}

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
@@ -72,7 +72,7 @@ public interface ISkinCommand {
 
         final String senderName = sender.getName();
         if (!sender.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(senderName)) {
-            sender.sendMessage(Locale.SKIN_COOLDOWN.replace("%s", "" + CooldownStorage.getCooldown(senderName)));
+            sender.sendMessage(Locale.SKIN_COOLDOWN.replace("%s", String.valueOf(CooldownStorage.getCooldown(senderName))));
             return false;
         }
 
@@ -81,7 +81,7 @@ public interface ISkinCommand {
         if (C.validUrl(skin)) {
             if (!sender.hasPermission("skinsrestorer.command.set.url")
                     && !Config.SKIN_WITHOUT_PERM
-                    && !clear) {// ignore /skin clear when defaultSkin = url
+                    && !clear) { // ignore /skin clear when defaultSkin = url
                 sender.sendMessage(Locale.PLAYER_HAS_NO_PERMISSION_URL);
                 return false;
             }
@@ -96,7 +96,7 @@ public interface ISkinCommand {
 
             try {
                 sender.sendMessage(Locale.MS_UPDATING_SKIN);
-                String skinentry = " " + pName; // so won't overwrite premium playernames
+                String skinentry = " " + pName; // so won't overwrite premium player names
                 if (skinentry.length() > 16) // max len of 16 char
                     skinentry = skinentry.substring(0, 16);
 
@@ -143,6 +143,8 @@ public interface ISkinCommand {
 
     void clearSkin(PlayerWrapper player);
 
+    void runAsync(Runnable runnable);
+    
     enum SkinType {
         STEVE,
         SLIM,

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
@@ -145,7 +145,7 @@ public interface ISkinCommand {
             final String sName = sender.getName();
             final String pName = player.getName();
             if (Config.PER_SKIN_PERMISSIONS && !sender.hasPermission("skinsrestorer.skin." + skin)) {
-                if (!sender.hasPermission("skinsrestorer.ownskin") && (!sender.equalsPlayer(player) || !skin.equalsIgnoreCase(sName))) { // Todo: Test: sender != player
+                if (!sender.hasPermission("skinsrestorer.ownskin") && (!sender.equalsPlayer(player) || !skin.equalsIgnoreCase(sName))) {
                     sender.sendMessage(Locale.PLAYER_HAS_NO_PERMISSION_SKIN);
                     return;
                 }

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
@@ -22,6 +22,7 @@ package net.skinsrestorer.shared.commands;
 import co.aikar.commands.CommandHelp;
 import co.aikar.commands.InvalidCommandArgument;
 import net.skinsrestorer.api.PlayerWrapper;
+import net.skinsrestorer.api.SkinVariant;
 import net.skinsrestorer.api.SkinsRestorerAPI;
 import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.interfaces.ISRCommandSender;
@@ -99,7 +100,7 @@ public interface ISkinCommand {
             }
 
             final String pName = player.getName();
-            java.util.Optional<String> skin = plugin.getSkinStorage().getSkinName(pName);
+            Optional<String> skin = plugin.getSkinStorage().getSkinName(pName);
 
             try {
                 if (skin.isPresent()) {
@@ -116,7 +117,7 @@ public interface ISkinCommand {
 
                 } else {
                     // get DefaultSkin
-                    skin = java.util.Optional.of(plugin.getSkinStorage().getDefaultSkinName(pName, true));
+                    skin = Optional.of(plugin.getSkinStorage().getDefaultSkinName(pName, true));
                 }
             } catch (SkinRequestException e) {
                 sender.sendMessage(e.getMessage());
@@ -139,7 +140,7 @@ public interface ISkinCommand {
         onSkinSetOther(player, player, skin[0], null);
     }
 
-    default void onSkinSetOther(ISRCommandSender sender, ISRPlayer player, String skin, SkinType skinType) {
+    default void onSkinSetOther(ISRCommandSender sender, ISRPlayer player, String skin, SkinVariant skinVariant) {
         ISRPlugin plugin = getPlugin();
         plugin.runAsync(() -> {
             final String sName = sender.getName();
@@ -151,18 +152,18 @@ public interface ISkinCommand {
                 }
             }
 
-            if (setSkin(sender, player.getWrapper(), skin, true, false, skinType) && (sender != player))
+            if (setSkin(sender, player.getWrapper(), skin, true, false, skinVariant) && (sender != player))
                 sender.sendMessage(Locale.ADMIN_SET_SKIN.replace("%player", pName));
         });
     }
 
-    default void onSkinSetUrl(ISRPlayer player, String url, SkinType skinType) {
+    default void onSkinSetUrl(ISRPlayer player, String url, SkinVariant skinVariant) {
         if (!C.validUrl(url)) {
             player.sendMessage(Locale.ERROR_INVALID_URLSKIN);
             return;
         }
 
-        onSkinSetOther(player, player, url, skinType);
+        onSkinSetOther(player, player, url, skinVariant);
     }
 
     default void sendHelp(ISRCommandSender sender) {
@@ -182,7 +183,7 @@ public interface ISkinCommand {
 
     // if save is false, we won't save the skin name
     // because default skin names shouldn't be saved as the users custom skin
-    default boolean setSkin(ISRCommandSender sender, PlayerWrapper player, String skin, boolean save, boolean clear, SkinType skinType) {
+    default boolean setSkin(ISRCommandSender sender, PlayerWrapper player, String skin, boolean save, boolean clear, SkinVariant skinVariant) {
         ISRPlugin plugin = getPlugin();
 
         if (skin.equalsIgnoreCase("null")) {
@@ -226,7 +227,7 @@ public interface ISkinCommand {
                 if (skinEntry.length() > 16) // max len of 16 char
                     skinEntry = skinEntry.substring(0, 16);
 
-                IProperty generatedSkin = SkinsRestorerAPI.getApi().genSkinUrl(skin, String.valueOf(skinType));
+                IProperty generatedSkin = SkinsRestorerAPI.getApi().genSkinUrl(skin, skinVariant);
                 plugin.getSkinStorage().setSkinData(skinEntry, generatedSkin,
                         System.currentTimeMillis() + Duration.of(100, ChronoUnit.YEARS).toMillis()); // "generate" and save skin for 100 years
                 plugin.getSkinStorage().setSkinName(playerName, skinEntry); // set player to "whitespaced" name then reload skin
@@ -273,9 +274,4 @@ public interface ISkinCommand {
     ISRPlugin getPlugin();
 
     void clearSkin(PlayerWrapper player);
-
-    enum SkinType {
-        STEVE,
-        SLIM,
-    }
 }

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
@@ -65,7 +65,7 @@ public interface ISkinCommand {
 
     default void onSkinClearOther(ISRCommandSender sender, ISRPlayer target) {
         ISRPlugin plugin = getPlugin();
-        runAsync(() -> {
+        plugin.runAsync(() -> {
             if (!sender.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(sender.getName())) {
                 sender.sendMessage(String.format(Locale.SKIN_COOLDOWN, CooldownStorage.getCooldown(sender.getName())));
                 return;
@@ -92,7 +92,7 @@ public interface ISkinCommand {
 
     default void onSkinUpdateOther(ISRCommandSender sender, ISRPlayer player) {
         ISRPlugin plugin = getPlugin();
-        runAsync(() -> {
+        plugin.runAsync(() -> {
             if (!sender.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(sender.getName())) {
                 sender.sendMessage(String.format(Locale.SKIN_COOLDOWN, CooldownStorage.getCooldown(sender.getName())));
                 return;
@@ -139,7 +139,8 @@ public interface ISkinCommand {
     }
 
     default void onSkinSetOther(ISRCommandSender sender, ISRPlayer player, String skin, @Optional SkinType skinType) {
-        runAsync(() -> {
+        ISRPlugin plugin = getPlugin();
+        plugin.runAsync(() -> {
             if (Config.PER_SKIN_PERMISSIONS && !sender.hasPermission("skinsrestorer.skin." + skin)) {
                 if (!sender.hasPermission("skinsrestorer.ownskin") && !sender.getName().equalsIgnoreCase(player.getName()) || !skin.equalsIgnoreCase(sender.getName())) {
                     sender.sendMessage(Locale.PLAYER_HAS_NO_PERMISSION_SKIN);
@@ -175,8 +176,6 @@ public interface ISkinCommand {
         if (save)
             getPlugin().getSkinStorage().setSkinName(pName, oldSkinName);
     }
-
-    ISRPlugin getPlugin();
 
     // if save is false, we won't save the skin name
     // because default skin names shouldn't be saved as the users custom skin
@@ -265,9 +264,9 @@ public interface ISkinCommand {
         return false;
     }
 
-    void clearSkin(PlayerWrapper player);
+    ISRPlugin getPlugin();
 
-    void runAsync(Runnable runnable);
+    void clearSkin(PlayerWrapper player);
 
     enum SkinType {
         STEVE,

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
@@ -1,4 +1,48 @@
+/*
+ * SkinsRestorer
+ *
+ * Copyright (C) 2022 SkinsRestorer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ */
 package net.skinsrestorer.shared.commands;
 
+import net.skinsrestorer.api.interfaces.ISRCommandSender;
+import net.skinsrestorer.shared.interfaces.ISRPlugin;
+import net.skinsrestorer.shared.storage.Locale;
+
 public interface ISkinCommand {
+    default void sendHelp(ISRCommandSender sender) {
+        if (!Locale.SR_LINE.isEmpty())
+            sender.sendMessage(Locale.SR_LINE);
+
+        sender.sendMessage(Locale.CUSTOM_HELP_IF_ENABLED.replace("%ver%", getPlugin().getVersion()));
+
+        if (!Locale.SR_LINE.isEmpty())
+            sender.sendMessage(Locale.SR_LINE);
+    }
+
+    default void rollback(String pName, String oldSkinName, boolean save) {
+        if (save)
+            getPlugin().getSkinStorage().setSkinName(pName, oldSkinName);
+    }
+
+    ISRPlugin getPlugin();
+
+    enum SkinType {
+        STEVE,
+        SLIM,
+    }
 }

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
@@ -1,0 +1,4 @@
+package net.skinsrestorer.shared.commands;
+
+public interface ISkinCommand {
+}

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
@@ -19,10 +19,14 @@
  */
 package net.skinsrestorer.shared.commands;
 
+import co.aikar.commands.CommandHelp;
+import co.aikar.commands.InvalidCommandArgument;
+import co.aikar.commands.annotation.Optional;
 import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.SkinsRestorerAPI;
 import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.interfaces.ISRCommandSender;
+import net.skinsrestorer.api.interfaces.ISRPlayer;
 import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.shared.interfaces.ISRPlugin;
 import net.skinsrestorer.shared.storage.Config;
@@ -34,8 +38,128 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 
+import static co.aikar.commands.CommandManager.getCurrentCommandManager;
+
 public interface ISkinCommand {
     IProperty emptySkin = SkinsRestorerAPI.getApi().createProperty("textures", "", "");
+
+    @SuppressWarnings("deprecation")
+    default void onDefault(ISRCommandSender sender) {
+        onHelp(sender, getCurrentCommandManager().generateCommandHelp());
+    }
+
+    default void onSkinSetShort(ISRPlayer player, String skin) {
+        onSkinSetOther(player, player, skin, null);
+    }
+
+    default void onHelp(ISRCommandSender sender, CommandHelp help) {
+        if (Config.ENABLE_CUSTOM_HELP)
+            sendHelp(sender);
+        else
+            help.showHelp();
+    }
+
+    default void onSkinClear(ISRPlayer player) {
+        onSkinClearOther(player, player);
+    }
+
+    default void onSkinClearOther(ISRCommandSender sender, ISRPlayer target) {
+        ISRPlugin plugin = getPlugin();
+        runAsync(() -> {
+            if (!sender.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(sender.getName())) {
+                sender.sendMessage(String.format(Locale.SKIN_COOLDOWN, CooldownStorage.getCooldown(sender.getName())));
+                return;
+            }
+
+            final String pName = target.getName();
+            final String skin = getPlugin().getSkinStorage().getDefaultSkinName(pName, true);
+
+            // remove users defined skin from database
+            plugin.getSkinStorage().removeSkin(pName);
+
+            if (setSkin(sender, target.getWrapper(), skin, false, true, null)) {
+                if (sender.getName().equals(target.getName()))
+                    sender.sendMessage(Locale.SKIN_CLEAR_SUCCESS);
+                else
+                    sender.sendMessage(String.format(Locale.SKIN_CLEAR_ISSUER, pName));
+            }
+        });
+    }
+
+    default void onSkinUpdate(ISRPlayer player) {
+        onSkinUpdateOther(player, player);
+    }
+
+    default void onSkinUpdateOther(ISRCommandSender sender, ISRPlayer player) {
+        ISRPlugin plugin = getPlugin();
+        runAsync(() -> {
+            if (!sender.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(sender.getName())) {
+                sender.sendMessage(String.format(Locale.SKIN_COOLDOWN, CooldownStorage.getCooldown(sender.getName())));
+                return;
+            }
+
+            java.util.Optional<String> skin = plugin.getSkinStorage().getSkinName(player.getName());
+
+            try {
+                if (skin.isPresent()) {
+                    //filter skinUrl
+                    if (skin.get().startsWith(" ")) {
+                        sender.sendMessage(Locale.ERROR_UPDATING_URL);
+                        return;
+                    }
+
+                    if (!plugin.getSkinStorage().updateSkinData(skin.get())) {
+                        sender.sendMessage(Locale.ERROR_UPDATING_SKIN);
+                        return;
+                    }
+
+                } else {
+                    // get DefaultSkin
+                    skin = java.util.Optional.of(plugin.getSkinStorage().getDefaultSkinName(player.getName(), true));
+                }
+            } catch (SkinRequestException e) {
+                sender.sendMessage(e.getMessage());
+                return;
+            }
+
+            if (setSkin(sender, player.getWrapper(), skin.get(), false, false, null)) {
+                if (sender == player)
+                    sender.sendMessage(String.format(Locale.SUCCESS_UPDATING_SKIN_OTHER, player.getName()));
+                else
+                    sender.sendMessage(Locale.SUCCESS_UPDATING_SKIN);
+            }
+        });
+    }
+
+    default void onSkinSet(ISRPlayer player, String[] skin) {
+        if (skin.length == 0)
+            throw new InvalidCommandArgument(true);
+
+        onSkinSetOther(player, player, skin[0], null);
+    }
+
+    default void onSkinSetOther(ISRCommandSender sender, ISRPlayer player, String skin, @Optional SkinType skinType) {
+        runAsync(() -> {
+            if (Config.PER_SKIN_PERMISSIONS && !sender.hasPermission("skinsrestorer.skin." + skin)) {
+                if (!sender.hasPermission("skinsrestorer.ownskin") && !sender.getName().equalsIgnoreCase(player.getName()) || !skin.equalsIgnoreCase(sender.getName())) {
+                    sender.sendMessage(Locale.PLAYER_HAS_NO_PERMISSION_SKIN);
+                    return;
+                }
+            }
+
+            if (setSkin(sender, player.getWrapper(), skin, true, false, skinType) && (sender != player))
+                sender.sendMessage(Locale.ADMIN_SET_SKIN.replace("%player", player.getName()));
+        });
+    }
+
+    default void onSkinSetUrl(ISRPlayer player, String url, @Optional SkinType skinType) {
+        if (!C.validUrl(url)) {
+            player.sendMessage(Locale.ERROR_INVALID_URLSKIN);
+            return;
+        }
+
+        onSkinSetOther(player, player, url, skinType);
+    }
 
     default void sendHelp(ISRCommandSender sender) {
         if (!Locale.SR_LINE.isEmpty())
@@ -105,10 +229,10 @@ public interface ISkinCommand {
                         System.currentTimeMillis() + Duration.of(100, ChronoUnit.YEARS).toMillis()); // "generate" and save skin for 100 years
                 plugin.getSkinStorage().setSkinName(pName, skinentry); // set player to "whitespaced" name then reload skin
                 SkinsRestorerAPI.getApi().applySkin(player, generatedSkin);
-                
+
                 if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
                     player.sendMessage(Locale.SKIN_CHANGE_SUCCESS.replace("%skin", "skinUrl"));
-                
+
                 return true;
             } catch (SkinRequestException e) {
                 sender.sendMessage(e.getMessage());
@@ -144,7 +268,7 @@ public interface ISkinCommand {
     void clearSkin(PlayerWrapper player);
 
     void runAsync(Runnable runnable);
-    
+
     enum SkinType {
         STEVE,
         SLIM,

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
@@ -19,11 +19,24 @@
  */
 package net.skinsrestorer.shared.commands;
 
+import net.skinsrestorer.api.PlayerWrapper;
+import net.skinsrestorer.api.SkinsRestorerAPI;
+import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.interfaces.ISRCommandSender;
+import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.shared.interfaces.ISRPlugin;
+import net.skinsrestorer.shared.storage.Config;
+import net.skinsrestorer.shared.storage.CooldownStorage;
 import net.skinsrestorer.shared.storage.Locale;
+import net.skinsrestorer.shared.utils.C;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
 
 public interface ISkinCommand {
+    IProperty emptySkin = SkinsRestorerAPI.getApi().createProperty("textures", "", "");
+
     default void sendHelp(ISRCommandSender sender) {
         if (!Locale.SR_LINE.isEmpty())
             sender.sendMessage(Locale.SR_LINE);
@@ -40,6 +53,95 @@ public interface ISkinCommand {
     }
 
     ISRPlugin getPlugin();
+
+    // if save is false, we won't save the skin name
+    // because default skin names shouldn't be saved as the users custom skin
+    default boolean setSkin(ISRCommandSender sender, PlayerWrapper player, String skin, boolean save, boolean clear, SkinType skinType) {
+        ISRPlugin plugin = getPlugin();
+
+        if (skin.equalsIgnoreCase("null")) {
+            sender.sendMessage(Locale.INVALID_PLAYER.replace("%player", skin));
+            return false;
+        }
+
+        if (Config.DISABLED_SKINS_ENABLED && !clear && !sender.hasPermission("skinsrestorer.bypassdisabled")
+                && Config.DISABLED_SKINS.stream().anyMatch(skin::equalsIgnoreCase)) {
+            sender.sendMessage(Locale.SKIN_DISABLED);
+            return false;
+        }
+
+        final String senderName = sender.getName();
+        if (!sender.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(senderName)) {
+            sender.sendMessage(Locale.SKIN_COOLDOWN.replace("%s", "" + CooldownStorage.getCooldown(senderName)));
+            return false;
+        }
+
+        final String pName = player.getName();
+        final java.util.Optional<String> oldSkinName = plugin.getSkinStorage().getSkinName(pName);
+        if (C.validUrl(skin)) {
+            if (!sender.hasPermission("skinsrestorer.command.set.url")
+                    && !Config.SKIN_WITHOUT_PERM
+                    && !clear) {// ignore /skin clear when defaultSkin = url
+                sender.sendMessage(Locale.PLAYER_HAS_NO_PERMISSION_URL);
+                return false;
+            }
+
+            if (!C.allowedSkinUrl(skin)) {
+                sender.sendMessage(Locale.SKINURL_DISALLOWED);
+                return false;
+            }
+
+            // Apply cooldown to sender
+            CooldownStorage.setCooldown(senderName, Config.SKIN_CHANGE_COOLDOWN, TimeUnit.SECONDS);
+
+            try {
+                sender.sendMessage(Locale.MS_UPDATING_SKIN);
+                String skinentry = " " + pName; // so won't overwrite premium playernames
+                if (skinentry.length() > 16) // max len of 16 char
+                    skinentry = skinentry.substring(0, 16);
+
+                IProperty generatedSkin = SkinsRestorerAPI.getApi().genSkinUrl(skin, String.valueOf(skinType));
+                plugin.getSkinStorage().setSkinData(skinentry, generatedSkin,
+                        System.currentTimeMillis() + Duration.of(100, ChronoUnit.YEARS).toMillis()); // "generate" and save skin for 100 years
+                plugin.getSkinStorage().setSkinName(pName, skinentry); // set player to "whitespaced" name then reload skin
+                SkinsRestorerAPI.getApi().applySkin(player, generatedSkin);
+                
+                if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
+                    player.sendMessage(Locale.SKIN_CHANGE_SUCCESS.replace("%skin", "skinUrl"));
+                
+                return true;
+            } catch (SkinRequestException e) {
+                sender.sendMessage(e.getMessage());
+            } catch (Exception e) {
+                plugin.getSrLogger().debug("[ERROR] Exception: could not generate skin url:" + skin + "\nReason= " + e.getMessage());
+                sender.sendMessage(Locale.ERROR_INVALID_URLSKIN);
+            }
+        } else {
+            // If skin is not an url, it's a username
+            try {
+                if (save)
+                    plugin.getSkinStorage().setSkinName(pName, skin);
+                // TODO: #getSkinForPlayer() is nested and on different places around bungee/sponge/velocity
+                SkinsRestorerAPI.getApi().applySkin(player, skin);
+                if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
+                    player.sendMessage(Locale.SKIN_CHANGE_SUCCESS.replace("%skin", skin)); // TODO: should this not be sender? -> hidden skin set?
+                return true;
+            } catch (SkinRequestException e) {
+                if (clear) {
+                    clearSkin(player);
+
+                    return true;
+                }
+                sender.sendMessage(e.getMessage());
+            }
+        }
+        // set CoolDown to ERROR_COOLDOWN and rollback to old skin on exception
+        CooldownStorage.setCooldown(senderName, Config.SKIN_ERROR_COOLDOWN, TimeUnit.SECONDS);
+        rollback(pName, oldSkinName.orElse(pName), save);
+        return false;
+    }
+
+    void clearSkin(PlayerWrapper player);
 
     enum SkinType {
         STEVE,

--- a/shared/src/main/java/net/skinsrestorer/shared/interfaces/ISRPlugin.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/interfaces/ISRPlugin.java
@@ -20,16 +20,19 @@
 package net.skinsrestorer.shared.interfaces;
 
 import co.aikar.commands.CommandManager;
+import net.skinsrestorer.api.interfaces.ISRPlayer;
 import net.skinsrestorer.shared.storage.SkinStorage;
 import net.skinsrestorer.shared.utils.CommandPropertiesManager;
 import net.skinsrestorer.shared.utils.CommandReplacements;
 import net.skinsrestorer.shared.utils.MetricsCounter;
 import net.skinsrestorer.shared.utils.SharedMethods;
+import net.skinsrestorer.shared.utils.connections.MojangAPI;
 import net.skinsrestorer.shared.utils.log.SRLogger;
 
 import java.io.File;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Collection;
 
 public interface ISRPlugin {
     File getDataFolder();
@@ -43,6 +46,10 @@ public interface ISRPlugin {
     SRLogger getSrLogger();
 
     InputStream getResource(String resource);
+
+    void runAsync(Runnable runnable);
+
+    Collection<ISRPlayer> getOnlinePlayers();
 
     @SuppressWarnings({"deprecation"})
     default void prepareACF(CommandManager<?, ?, ?, ?, ?, ?> manager, SRLogger srLogger) {
@@ -59,4 +66,8 @@ public interface ISRPlugin {
 
         SharedMethods.allowIllegalACFNames();
     }
+
+    CommandManager<?, ?, ?, ?, ?, ?> getManager();
+
+    MojangAPI getMojangAPI();
 }

--- a/shared/src/main/java/net/skinsrestorer/shared/interfaces/ISRPlugin.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/interfaces/ISRPlugin.java
@@ -40,6 +40,8 @@ public interface ISRPlugin {
 
     MetricsCounter getMetricsCounter();
 
+    SRLogger getSrLogger();
+
     InputStream getResource(String resource);
 
     @SuppressWarnings({"deprecation"})

--- a/shared/src/main/java/net/skinsrestorer/shared/storage/CooldownStorage.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/storage/CooldownStorage.java
@@ -36,7 +36,7 @@ public class CooldownStorage implements Runnable {
         cooldown.remove(name);
     }
 
-    public static int getCooldown(String name) {
+    public static int getCooldown(String name) { // Todo: improve performance
         int int1 = Integer.parseInt(String.format("%d", TimeUnit.MILLISECONDS.toSeconds(cooldown.get(name))));
         int int2 = Integer.parseInt(String.format("%d", TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis())));
         return int1 - int2;

--- a/shared/src/main/java/net/skinsrestorer/shared/storage/Locale.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/storage/Locale.java
@@ -56,7 +56,7 @@ public class Locale {
     public static String SYNTAX_DEFAULTCOMMAND = " <skin/url>";
     public static String SYNTAX_SKINSET = " <skin>";
     public static String SYNTAX_SKINSET_OTHER = " <target> <skin/url>";
-    public static String SYNTAX_SKINURL = " <SkinUrl> [steve/slim]";
+    public static String SYNTAX_SKINURL = " <SkinUrl> [classic/slim]";
     public static String SYNTAX_SKINUPDATE_OTHER = " <target>";
     public static String SYNTAX_SKINCLEAR_OTHER = " <target>";
     public static String COMPLETIONS_SKIN = "<Skin>";

--- a/shared/src/main/java/net/skinsrestorer/shared/storage/SkinStorage.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/storage/SkinStorage.java
@@ -43,6 +43,11 @@ import java.util.regex.Pattern;
 
 @RequiredArgsConstructor
 public class SkinStorage implements ISkinStorage {
+    private static final Pattern FORBIDDENCHARS_PATTERN = Pattern.compile("[\\\\/:*?\"<>|\\.]");
+    private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s");
+    private static final String LTRIM = "^\\\\s+";
+    private static final String RTRIM = "\\\\s+$";
+    private static final Pattern PTRIM = Pattern.compile("(" + LTRIM + "|" + RTRIM + ")");
     private final SRLogger logger;
     private final MojangAPI mojangAPI;
     private final MineSkinAPI mineSkinAPI;
@@ -50,11 +55,6 @@ public class SkinStorage implements ISkinStorage {
     private MySQL mysql;
     private File skinsFolder;
     private File playersFolder;
-    private static final Pattern FORBIDDENCHARS_PATTERN = Pattern.compile("[\\\\/:*?\"<>|\\.]");
-    private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s");
-    private static final String LTRIM = "^\\\\s+";
-    private static final String RTRIM = "\\\\s+$";
-    private static final Pattern PTRIM = Pattern.compile("("+LTRIM+"|"+RTRIM+")");
 
     public void loadFolders(File pluginFolder) {
         skinsFolder = new File(pluginFolder, "Skins");

--- a/shared/src/main/java/net/skinsrestorer/shared/utils/C.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/utils/C.java
@@ -45,7 +45,7 @@ public class C {
     }
 
     public static boolean validMojangUsername(String username) {
-        //Note: there are exceptions of players with under 3 characters, who bought the game early in its development.
+        // Note: there are exceptions to players with under 3 characters, who bought the game early in its development.
         if (username.length() > 16)
             return false;
 
@@ -63,8 +63,10 @@ public class C {
                     return true;
                 }
             }
+
             return false;
+        } else {
+            return true;
         }
-        return true;
     }
 }

--- a/shared/src/main/java/net/skinsrestorer/shared/utils/WrapperFactory.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/utils/WrapperFactory.java
@@ -23,5 +23,5 @@ import net.skinsrestorer.api.interfaces.ISRPlayer;
 import net.skinsrestorer.api.interfaces.IWrapperFactory;
 
 public abstract class WrapperFactory implements IWrapperFactory {
-    public abstract ISRPlayer wrap(Object playerInstance);
+    public abstract ISRPlayer wrapPlayer(Object playerInstance);
 }

--- a/shared/src/main/java/net/skinsrestorer/shared/utils/connections/MineSkinAPI.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/utils/connections/MineSkinAPI.java
@@ -23,6 +23,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.api.SkinVariant;
 import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.interfaces.IMineSkinAPI;
 import net.skinsrestorer.api.property.IProperty;
@@ -52,7 +53,8 @@ public class MineSkinAPI implements IMineSkinAPI {
     private final Queue<UUID> queue = new LinkedList<>();
     private final Map<UUID, AtomicInteger> fails = new HashMap<>();
 
-    public IProperty genSkin(String url, @Nullable String skinType, @Nullable UUID methodUUID) throws SkinRequestException {
+    @Override
+    public IProperty genSkin(String url, @Nullable SkinVariant skinVariant, @Nullable UUID methodUUID) throws SkinRequestException {
         if (methodUUID == null) {
             methodUUID = UUID.randomUUID();
             queue.add(methodUUID);
@@ -67,11 +69,11 @@ public class MineSkinAPI implements IMineSkinAPI {
 
         try {
             if (queue.element().equals(methodUUID)) {
-                String skinVariant = skinType != null && (skinType.equalsIgnoreCase("steve") || skinType.equalsIgnoreCase("slim")) ? "&variant=" + skinType : "";
+                String skinVariantString = skinVariant != null ? "&variant=" + skinVariant.name().toLowerCase() : "";
 
                 try {
-                    final String output = queryURL("url=" + URLEncoder.encode(url, "UTF-8") + skinVariant);
-                    if (output.isEmpty()) //api time out
+                    final String output = queryURL("url=" + URLEncoder.encode(url, "UTF-8") + skinVariantString);
+                    if (output.isEmpty()) // API time out
                         throw new SkinRequestException(Locale.ERROR_UPDATING_SKIN);
 
                     final JsonObject obj = JsonParser.parseString(output).getAsJsonObject();
@@ -104,14 +106,14 @@ public class MineSkinAPI implements IMineSkinAPI {
                                     TimeUnit.SECONDS.sleep(2);
                                 }
 
-                                return genSkin(url, skinType, methodUUID); // try again after nextRequest
+                                return genSkin(url, skinVariant, methodUUID); // try again after nextRequest
 
                             case "Failed to generate skin data":
                             case "Failed to change skin":
                                 logger.debug("[ERROR] MS " + errResp + ", trying again... ");
                                 TimeUnit.SECONDS.sleep(5);
 
-                                return genSkin(url, skinType, methodUUID); // try again
+                                return genSkin(url, skinVariant, methodUUID); // try again
 
                             case "No accounts available":
                                 logger.debug("[ERROR] " + errResp + " for: " + url);
@@ -143,7 +145,7 @@ public class MineSkinAPI implements IMineSkinAPI {
                     throw new SkinRequestException(Locale.MS_API_FAILED);
                 }
 
-                return genSkin(url, skinType, methodUUID);
+                return genSkin(url, skinVariant, methodUUID);
             }
         } finally {
             queue.remove(methodUUID);

--- a/shared/src/main/java/net/skinsrestorer/shared/utils/log/LoggerImpl.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/utils/log/LoggerImpl.java
@@ -28,7 +28,6 @@ import java.util.logging.Logger;
 
 @RequiredArgsConstructor
 public class LoggerImpl implements ISRLogger {
-    @SuppressWarnings("SpongeLogging")
     private final Logger logger;
     private final ISRConsole console;
 

--- a/shared/src/main/resources/languages/english.yml
+++ b/shared/src/main/resources/languages/english.yml
@@ -37,7 +37,7 @@ help-SRCreateCustom: "Create a custom server wide skin."
 syntax-Defaultcommand: " <skin/url>"
 syntax-SkinSet: " <skin>"
 syntax-SkinSet-Other: " <target> <skin/url>"
-syntax-SkinUrl: " <SkinUrl> [steve/slim]"
+syntax-SkinUrl: " <SkinUrl> [classic/slim]"
 syntax-SkinUpdate-Other: " <target>"
 syntax-SkinClear-Other: " <target>"
 

--- a/sponge/src/main/java/net/skinsrestorer/sponge/SkinsRestorer.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/SkinsRestorer.java
@@ -149,7 +149,7 @@ public class SkinsRestorer implements ISRPlugin {
 
             prepareACF(manager, srLogger);
 
-            manager.registerCommand(new SkinCommand(this, srLogger));
+            manager.registerCommand(new SkinCommand(this));
             manager.registerCommand(new SrCommand(this, srLogger));
         });
     }

--- a/sponge/src/main/java/net/skinsrestorer/sponge/SkinsRestorer.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/SkinsRestorer.java
@@ -45,6 +45,7 @@ import net.skinsrestorer.shared.utils.log.Slf4LoggerImpl;
 import net.skinsrestorer.sponge.commands.SkinCommand;
 import net.skinsrestorer.sponge.commands.SrCommand;
 import net.skinsrestorer.sponge.listeners.LoginListener;
+import net.skinsrestorer.sponge.utils.WrapperSponge;
 import org.bstats.charts.SingleLineChart;
 import org.bstats.sponge.Metrics;
 import org.inventivetalent.update.spiget.UpdateCallback;
@@ -200,26 +201,11 @@ public class SkinsRestorer implements ISRPlugin {
 
     private static class WrapperFactorySponge extends WrapperFactory {
         @Override
-        public ISRPlayer wrap(Object playerInstance) {
+        public ISRPlayer wrapPlayer(Object playerInstance) {
             if (playerInstance instanceof Player) {
                 Player player = (Player) playerInstance;
 
-                return new ISRPlayer() {
-                    @Override
-                    public PlayerWrapper getWrapper() {
-                        return new PlayerWrapper(playerInstance);
-                    }
-
-                    @Override
-                    public String getName() {
-                        return player.getName();
-                    }
-
-                    @Override
-                    public void sendMessage(String message) {
-                        player.sendMessage(Text.builder(message).build());
-                    }
-                };
+                return WrapperSponge.wrapPlayer(player);
             } else {
                 throw new IllegalArgumentException("Player instance is not valid!");
             }

--- a/sponge/src/main/java/net/skinsrestorer/sponge/SkinsRestorer.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/SkinsRestorer.java
@@ -60,13 +60,14 @@ import org.spongepowered.api.event.game.state.GameStartedServerEvent;
 import org.spongepowered.api.event.network.ClientConnectionEvent;
 import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.plugin.PluginContainer;
-import org.spongepowered.api.text.Text;
 
 import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Getter
 @Plugin(id = "skinsrestorer", name = "SkinsRestorer", version = BuildData.VERSION, description = BuildData.DESCRIPTION, url = BuildData.URL, authors = {"Blackfire62", "McLive"})
@@ -151,7 +152,7 @@ public class SkinsRestorer implements ISRPlugin {
             prepareACF(manager, srLogger);
 
             manager.registerCommand(new SkinCommand(this));
-            manager.registerCommand(new SrCommand(this, srLogger));
+            manager.registerCommand(new SrCommand(this));
         });
     }
 
@@ -185,10 +186,6 @@ public class SkinsRestorer implements ISRPlugin {
         }));
     }
 
-    public Text parseMessage(String msg) {
-        return Text.builder(msg).build();
-    }
-
     @Override
     public String getVersion() {
         return container.getVersion().orElse("Unknown");
@@ -197,6 +194,16 @@ public class SkinsRestorer implements ISRPlugin {
     @Override
     public InputStream getResource(String resource) {
         return getClass().getClassLoader().getResourceAsStream(resource);
+    }
+
+    @Override
+    public void runAsync(Runnable runnable) {
+        game.getScheduler().createAsyncExecutor(this).execute(runnable);
+    }
+
+    @Override
+    public Collection<ISRPlayer> getOnlinePlayers() {
+        return game.getServer().getOnlinePlayers().stream().map(WrapperSponge::wrapPlayer).collect(Collectors.toList());
     }
 
     private static class WrapperFactorySponge extends WrapperFactory {

--- a/sponge/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
@@ -29,20 +29,16 @@ import lombok.RequiredArgsConstructor;
 import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.interfaces.ISRCommandSender;
-import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.shared.commands.ISkinCommand;
 import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.storage.CooldownStorage;
 import net.skinsrestorer.shared.storage.Locale;
 import net.skinsrestorer.shared.utils.C;
-import net.skinsrestorer.shared.utils.log.SRLogger;
 import net.skinsrestorer.sponge.SkinsRestorer;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
-
-import java.util.concurrent.TimeUnit;
 
 @RequiredArgsConstructor
 @CommandAlias("skin")
@@ -210,78 +206,9 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
         onSkinSetOther(player, new OnlinePlayer(player), url, skinType);
     }
 
-    // if save is false, we won't save the skin skin name
-    // because default skin names shouldn't be saved as the users custom skin
-    private boolean setSkin(ISRCommandSender source, PlayerWrapper player, String skin, boolean save, boolean clear, SkinType skinType) {
-        if (skin.equalsIgnoreCase("null")) {
-            source.sendMessage(Locale.INVALID_PLAYER.replace("%player", skin));
-            return false;
-        }
-
-        if (Config.DISABLED_SKINS_ENABLED && !clear && !source.hasPermission("skinsrestorer.bypassdisabled")) {
-            for (String dskin : Config.DISABLED_SKINS)
-                if (skin.equalsIgnoreCase(dskin)) {
-                    source.sendMessage(Locale.SKIN_DISABLED);
-                    return false;
-                }
-        }
-
-        final String senderName = source.getName();
-        if (!source.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(senderName)) {
-            source.sendMessage(Locale.SKIN_COOLDOWN.replace("%s", "" + CooldownStorage.getCooldown(senderName)));
-            return false;
-        }
-
-        CooldownStorage.setCooldown(senderName, Config.SKIN_CHANGE_COOLDOWN, TimeUnit.SECONDS);
-
-        final String pName = player.getName();
-        final java.util.Optional<String> oldSkinName = plugin.getSkinStorage().getSkinName(pName);
-
-        if (C.validUrl(skin)) {
-            if (!source.hasPermission("skinsrestorer.command.set.url") && !Config.SKIN_WITHOUT_PERM) {
-                source.sendMessage(Locale.PLAYER_HAS_NO_PERMISSION_URL);
-                CooldownStorage.resetCooldown(senderName);
-                return false;
-            }
-
-            if (!C.allowedSkinUrl(skin)) {
-                source.sendMessage(Locale.SKINURL_DISALLOWED);
-                CooldownStorage.resetCooldown(senderName);
-                return false;
-            }
-
-            try {
-                source.sendMessage(Locale.MS_UPDATING_SKIN);
-                String skinentry = " " + pName; // so won't overwrite premium playernames
-                if (skinentry.length() > 16) // max len of 16 char
-                    skinentry = skinentry.substring(0, 16);
-
-                IProperty generatedSkin = plugin.getMineSkinAPI().genSkin(skin, String.valueOf(skinType), null);
-                plugin.getSkinStorage().setSkinData(skinentry, generatedSkin,
-                        System.currentTimeMillis() + (100L * 365 * 24 * 60 * 60 * 1000)); // "generate" and save skin for 100 years
-                plugin.getSkinStorage().setSkinName(pName, skinentry); // set player to "whitespaced" name then reload skin
-                plugin.getSkinsRestorerAPI().applySkin(player, generatedSkin);
-                if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
-                    player.sendMessage(Locale.SKIN_CHANGE_SUCCESS.replace("%skin", "skinUrl"));
-                return true;
-            } catch (SkinRequestException e) {
-                source.sendMessage(e.getMessage());
-            }
-        } else {
-            try {
-                if (save)
-                    plugin.getSkinStorage().setSkinName(pName, skin);
-                plugin.getSkinsRestorerAPI().applySkin(player);
-                if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
-                    player.sendMessage(Locale.SKIN_CHANGE_SUCCESS.replace("%skin", skin));
-                return true;
-            } catch (SkinRequestException e) {
-                source.sendMessage(e.getMessage());
-            }
-        }
-        CooldownStorage.setCooldown(senderName, Config.SKIN_ERROR_COOLDOWN, TimeUnit.SECONDS);
-        rollback(pName, oldSkinName.orElse(pName), save);
-        return false;
+    @Override
+    public void clearSkin(PlayerWrapper player) {
+        // TODO: Maybe do something here?
     }
 
     private ISRCommandSender wrap(CommandSource sender) {

--- a/sponge/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
@@ -125,9 +125,4 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     public void clearSkin(PlayerWrapper player) {
         // TODO: Maybe do something here?
     }
-
-    @Override
-    public void runAsync(Runnable runnable) {
-        plugin.getGame().getScheduler().createAsyncExecutor(plugin).execute(runnable);
-    }
 }

--- a/sponge/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
@@ -25,8 +25,8 @@ import co.aikar.commands.annotation.*;
 import co.aikar.commands.sponge.contexts.OnlinePlayer;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.SkinVariant;
+import net.skinsrestorer.api.interfaces.ISRPlayer;
 import net.skinsrestorer.shared.commands.ISkinCommand;
 import net.skinsrestorer.sponge.SkinsRestorer;
 import org.spongepowered.api.command.CommandSource;
@@ -123,7 +123,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     }
 
     @Override
-    public void clearSkin(PlayerWrapper player) {
+    public void clearSkin(ISRPlayer player) {
         // TODO: Maybe do something here?
     }
 }

--- a/sponge/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
@@ -84,7 +84,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Syntax("%SyntaxSkinClearOther")
     @Description("%helpSkinClearOther")
     public void onSkinClearOther(CommandSource source, @Single OnlinePlayer target) {
-        Sponge.getScheduler().createAsyncExecutor(plugin).execute(() -> {
+        runAsync(() -> {
             if (!source.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(source.getName())) {
                 source.sendMessage(plugin.parseMessage(Locale.SKIN_COOLDOWN.replace("%s", "" + CooldownStorage.getCooldown(source.getName()))));
                 return;
@@ -120,7 +120,8 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Description("%helpSkinUpdateOther")
     @Syntax("%SyntaxSkinUpdateOther")
     public void onSkinUpdateOther(CommandSource source, @Single OnlinePlayer target) {
-        Sponge.getScheduler().createAsyncExecutor(plugin).execute(() -> {
+        ISRCommandSender wrapped = wrap(source);
+        runAsync(() -> {
             if (!source.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(source.getName())) {
                 source.sendMessage(plugin.parseMessage(Locale.SKIN_COOLDOWN.replace("%s", "" + CooldownStorage.getCooldown(source.getName()))));
                 return;
@@ -178,7 +179,8 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Description("%helpSkinSetOther")
     @Syntax("%SyntaxSkinSetOther")
     public void onSkinSetOther(CommandSource source, OnlinePlayer target, String skin, @Optional SkinType skinType) {
-        Sponge.getScheduler().createAsyncExecutor(plugin).execute(() -> {
+        ISRCommandSender wrapped = wrap(source);
+        runAsync(() -> {
             final Player player = target.getPlayer();
             if (Config.PER_SKIN_PERMISSIONS && !source.hasPermission("skinsrestorer.skin." + skin)) {
                 if (!source.hasPermission("skinsrestorer.ownskin") && !source.getName().equalsIgnoreCase(player.getName()) || !skin.equalsIgnoreCase(source.getName())) {
@@ -186,7 +188,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
                     return;
                 }
             }
-            if (setSkin(wrap(source), new PlayerWrapper(player), skin, true, false, skinType) && (source != player))
+            if (setSkin(wrapped, new PlayerWrapper(player), skin, true, false, skinType) && (source != player))
                 source.sendMessage(plugin.parseMessage(Locale.ADMIN_SET_SKIN.replace("%player", player.getName())));
         });
     }
@@ -209,6 +211,11 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Override
     public void clearSkin(PlayerWrapper player) {
         // TODO: Maybe do something here?
+    }
+
+    @Override
+    public void runAsync(Runnable runnable) {
+        plugin.getGame().getScheduler().createAsyncExecutor(plugin).execute(runnable);
     }
 
     private ISRCommandSender wrap(CommandSource sender) {

--- a/sponge/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
@@ -29,6 +29,7 @@ import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.interfaces.ISRCommandSender;
 import net.skinsrestorer.api.property.IProperty;
+import net.skinsrestorer.shared.commands.ISkinCommand;
 import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.storage.CooldownStorage;
 import net.skinsrestorer.shared.storage.Locale;
@@ -45,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 @CommandAlias("skin")
 @CommandPermission("%skin")
-public class SkinCommand extends BaseCommand {
+public class SkinCommand extends BaseCommand implements ISkinCommand {
     private final SkinsRestorer plugin;
     private final SRLogger log;
 

--- a/sponge/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
@@ -26,6 +26,7 @@ import co.aikar.commands.sponge.contexts.OnlinePlayer;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.skinsrestorer.api.PlayerWrapper;
+import net.skinsrestorer.api.SkinVariant;
 import net.skinsrestorer.shared.commands.ISkinCommand;
 import net.skinsrestorer.sponge.SkinsRestorer;
 import org.spongepowered.api.command.CommandSource;
@@ -108,8 +109,8 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @CommandCompletion("@players @skin")
     @Description("%helpSkinSetOther")
     @Syntax("%SyntaxSkinSetOther")
-    public void onSkinSetOther(CommandSource source, OnlinePlayer target, String skin, @Optional SkinType skinType) {
-        onSkinSetOther(wrapCommandSender(source), wrapPlayer(target.getPlayer()), skin, skinType);
+    public void onSkinSetOther(CommandSource source, OnlinePlayer target, String skin, @Optional SkinVariant skinVariant) {
+        onSkinSetOther(wrapCommandSender(source), wrapPlayer(target.getPlayer()), skin, skinVariant);
     }
 
     @Subcommand("url")
@@ -117,8 +118,8 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @CommandCompletion("@skinUrl")
     @Description("%helpSkinSetUrl")
     @Syntax("%SyntaxSkinUrl")
-    public void onSkinSetUrl(Player player, String url, @Optional SkinType skinType) {
-        onSkinSetUrl(wrapPlayer(player), url, skinType);
+    public void onSkinSetUrl(Player player, String url, @Optional SkinVariant skinVariant) {
+        onSkinSetUrl(wrapPlayer(player), url, skinVariant);
     }
 
     @Override

--- a/sponge/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/commands/SkinCommand.java
@@ -24,6 +24,7 @@ import co.aikar.commands.CommandHelp;
 import co.aikar.commands.InvalidCommandArgument;
 import co.aikar.commands.annotation.*;
 import co.aikar.commands.sponge.contexts.OnlinePlayer;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.exception.SkinRequestException;
@@ -47,8 +48,8 @@ import java.util.concurrent.TimeUnit;
 @CommandAlias("skin")
 @CommandPermission("%skin")
 public class SkinCommand extends BaseCommand implements ISkinCommand {
+    @Getter
     private final SkinsRestorer plugin;
-    private final SRLogger log;
 
     @Default
     @SuppressWarnings({"deprecation"})
@@ -60,7 +61,6 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @CommandPermission("%skinSet")
     @Description("%helpSkinSet")
     @Syntax("%SyntaxDefaultCommand")
-    @SuppressWarnings({"unused"})
     public void onSkinSetShort(Player player, @Single String skin) {
         onSkinSetOther(player, new OnlinePlayer(player), skin, null);
     }
@@ -68,8 +68,9 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @HelpCommand
     @Syntax(" [help]")
     public void onHelp(CommandSource source, CommandHelp help) {
+        ISRCommandSender wrapped = wrap(source);
         if (Config.ENABLE_CUSTOM_HELP)
-            sendHelp(source);
+            sendHelp(wrapped);
         else
             help.showHelp();
     }
@@ -77,7 +78,6 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Subcommand("clear")
     @CommandPermission("%skinClear")
     @Description("%helpSkinClear")
-    @SuppressWarnings({"unused"})
     public void onSkinClear(Player player) {
         onSkinClearOther(player, new OnlinePlayer(player));
     }
@@ -114,7 +114,6 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Subcommand("update")
     @CommandPermission("%skinUpdate")
     @Description("%helpSkinUpdate")
-    @SuppressWarnings({"unused"})
     public void onSkinUpdate(Player player) {
         onSkinUpdateOther(player, new OnlinePlayer(player));
     }
@@ -211,10 +210,6 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
         onSkinSetOther(player, new OnlinePlayer(player), url, skinType);
     }
 
-    private boolean setSkin(CommandSource source, Player player, String skin) {
-        return setSkin(wrap(source), new PlayerWrapper(player), skin, true, false, null);
-    }
-
     // if save is false, we won't save the skin skin name
     // because default skin names shouldn't be saved as the users custom skin
     private boolean setSkin(ISRCommandSender source, PlayerWrapper player, String skin, boolean save, boolean clear, SkinType skinType) {
@@ -289,19 +284,6 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
         return false;
     }
 
-    private void rollback(String pName, String oldSkinName, boolean save) {
-        if (save)
-            plugin.getSkinStorage().setSkinName(pName, oldSkinName);
-    }
-
-    private void sendHelp(CommandSource source) {
-        if (!Locale.SR_LINE.isEmpty())
-            source.sendMessage(plugin.parseMessage(Locale.SR_LINE));
-        source.sendMessage(plugin.parseMessage(Locale.CUSTOM_HELP_IF_ENABLED.replace("%ver%", plugin.getVersion())));
-        if (!Locale.SR_LINE.isEmpty())
-            source.sendMessage(plugin.parseMessage(Locale.SR_LINE));
-    }
-
     private ISRCommandSender wrap(CommandSource sender) {
         return new ISRCommandSender() {
             @Override
@@ -319,11 +301,5 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
                 return sender.hasPermission(permission);
             }
         };
-    }
-
-    @SuppressWarnings("unused")
-    public enum SkinType {
-        STEVE,
-        SLIM,
     }
 }

--- a/sponge/src/main/java/net/skinsrestorer/sponge/commands/SrCommand.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/commands/SrCommand.java
@@ -25,9 +25,18 @@ import co.aikar.commands.annotation.*;
 import co.aikar.commands.sponge.contexts.OnlinePlayer;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.api.interfaces.ISRPlayer;
+import net.skinsrestorer.api.property.GenericProperty;
+import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.shared.commands.ISRCommand;
 import net.skinsrestorer.sponge.SkinsRestorer;
 import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.profile.property.ProfileProperty;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static net.skinsrestorer.sponge.utils.WrapperSponge.wrapCommandSender;
 import static net.skinsrestorer.sponge.utils.WrapperSponge.wrapPlayer;
@@ -111,5 +120,13 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Override
     public String getProxyMode() {
         return "Sponge-Plugin";
+    }
+
+    @Override
+    public List<IProperty> getPropertiesOfPlayer(ISRPlayer player) {
+        Collection<ProfileProperty> properties = player.getWrapper().get(Player.class).getProfile().getPropertyMap().get("textures");
+        return properties.stream()
+                .map(property -> new GenericProperty(property.getName(), property.getValue(), property.getSignature().orElse("")))
+                .collect(Collectors.toList());
     }
 }

--- a/sponge/src/main/java/net/skinsrestorer/sponge/commands/SrCommand.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/commands/SrCommand.java
@@ -29,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.property.IProperty;
+import net.skinsrestorer.shared.commands.ISRCommand;
 import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.storage.Locale;
 import net.skinsrestorer.shared.utils.C;
@@ -48,7 +49,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @CommandAlias("sr|skinsrestorer")
 @CommandPermission("%sr")
-public class SrCommand extends BaseCommand {
+public class SrCommand extends BaseCommand implements ISRCommand {
     private final SkinsRestorer plugin;
     private final SRLogger logger;
 

--- a/sponge/src/main/java/net/skinsrestorer/sponge/commands/SrCommand.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/commands/SrCommand.java
@@ -23,88 +23,40 @@ import co.aikar.commands.BaseCommand;
 import co.aikar.commands.CommandHelp;
 import co.aikar.commands.annotation.*;
 import co.aikar.commands.sponge.contexts.OnlinePlayer;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.skinsrestorer.api.PlayerWrapper;
-import net.skinsrestorer.api.exception.SkinRequestException;
-import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.shared.commands.ISRCommand;
-import net.skinsrestorer.shared.storage.Config;
-import net.skinsrestorer.shared.storage.Locale;
-import net.skinsrestorer.shared.utils.C;
-import net.skinsrestorer.shared.utils.connections.ServiceChecker;
-import net.skinsrestorer.shared.utils.log.SRLogger;
 import net.skinsrestorer.sponge.SkinsRestorer;
-import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandSource;
-import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.profile.property.ProfileProperty;
 
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.List;
+import static net.skinsrestorer.sponge.utils.WrapperSponge.wrapCommandSender;
+import static net.skinsrestorer.sponge.utils.WrapperSponge.wrapPlayer;
 
 @RequiredArgsConstructor
 @CommandAlias("sr|skinsrestorer")
 @CommandPermission("%sr")
 public class SrCommand extends BaseCommand implements ISRCommand {
+    @Getter
     private final SkinsRestorer plugin;
-    private final SRLogger logger;
 
     @HelpCommand
     @Syntax(" [help]")
     public void onHelp(CommandSource source, CommandHelp help) {
-        help.showHelp();
+        onHelp(wrapCommandSender(source), help);
     }
 
     @Subcommand("reload")
     @CommandPermission("%srReload")
     @Description("%helpSrReload")
     public void onReload(CommandSource source) {
-        Locale.load(plugin.getDataFolder(), logger);
-        Config.load(plugin.getDataFolder(), plugin.getClass().getClassLoader().getResourceAsStream("config.yml"), logger);
-
-        plugin.prepareACF(plugin.getManager(), plugin.getSrLogger());
-
-        source.sendMessage(plugin.parseMessage(Locale.RELOAD));
+        onReload(wrapCommandSender(source));
     }
 
     @Subcommand("status")
     @CommandPermission("%srStatus")
     @Description("%helpSrStatus")
     public void onStatus(CommandSource source) {
-        Sponge.getScheduler().createAsyncExecutor(plugin).execute(() -> {
-            source.sendMessage(plugin.parseMessage("§3----------------------------------------------"));
-            source.sendMessage(plugin.parseMessage("§7Checking needed services for SR to work properly..."));
-
-            ServiceChecker checker = new ServiceChecker();
-            checker.setMojangAPI(plugin.getMojangAPI());
-            checker.checkServices();
-
-            ServiceChecker.ServiceCheckResponse response = checker.getResponse();
-            List<String> results = response.getResults();
-
-            if (Config.DEBUG || !(response.getWorkingUUID().get() >= 1) || !(response.getWorkingProfile().get() >= 1))
-                for (String result : results) {
-                    if (Config.DEBUG || result.contains("✘"))
-                        source.sendMessage(plugin.parseMessage(result));
-                }
-            source.sendMessage(plugin.parseMessage("§7Working UUID API count: §6" + response.getWorkingUUID()));
-            source.sendMessage(plugin.parseMessage("§7Working Profile API count: §6" + response.getWorkingProfile()));
-
-            if (response.getWorkingUUID().get() >= 1 && response.getWorkingProfile().get() >= 1)
-                source.sendMessage(plugin.parseMessage("§aThe plugin currently is in a working state."));
-            else
-                source.sendMessage(plugin.parseMessage("§cPlugin currently can't fetch new skins. \n Connection is likely blocked because of firewall. \n Please See http://skinsrestorer.net/firewall for more info"));
-            source.sendMessage(plugin.parseMessage("§3----------------------------------------------"));
-            source.sendMessage(plugin.parseMessage("§7SkinsRestorer §6v" + plugin.getVersion()));
-            source.sendMessage(plugin.parseMessage("§7Server: §6" + Sponge.getGame().getPlatform().getMinecraftVersion()));
-            source.sendMessage(plugin.parseMessage("§7BungeeMode: §6Sponge-Plugin"));
-            source.sendMessage(plugin.parseMessage("§7Finished checking services."));
-            source.sendMessage(plugin.parseMessage("§3----------------------------------------------"));
-        });
+        onStatus(wrapCommandSender(source));
     }
 
     @Subcommand("drop|remove")
@@ -113,16 +65,7 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("%helpSrDrop")
     @Syntax(" <player|skin> <target> [target2]")
     public void onDrop(CommandSource source, PlayerOrSkin playerOrSkin, String[] targets) {
-        Sponge.getScheduler().createAsyncExecutor(plugin).execute(() -> {
-            if (playerOrSkin == PlayerOrSkin.PLAYER)
-                for (String targetPlayer : targets)
-                    plugin.getSkinStorage().removeSkin(targetPlayer);
-            else
-                for (String targetSkin : targets)
-                    plugin.getSkinStorage().removeSkinData(targetSkin);
-            String targetList = Arrays.toString(targets).substring(1, Arrays.toString(targets).length() - 1);
-            source.sendMessage(plugin.parseMessage(Locale.DATA_DROPPED.replace("%playerOrSkin", playerOrSkin.toString()).replace("%targets", targetList)));
-        });
+        onDrop(wrapCommandSender(source), playerOrSkin, targets);
     }
 
     @Subcommand("props")
@@ -131,36 +74,7 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("%helpSrProps")
     @Syntax(" <target>")
     public void onProps(CommandSource source, @Single OnlinePlayer target) {
-        Sponge.getScheduler().createAsyncExecutor(plugin).execute(() -> {
-            Collection<ProfileProperty> prop = target.getPlayer().getProfile().getPropertyMap().get("textures");
-
-            if (prop == null) {
-                source.sendMessage(plugin.parseMessage(Locale.NO_SKIN_DATA));
-                return;
-            }
-
-            prop.forEach(profileProperty -> {
-                byte[] decoded = Base64.getDecoder().decode(profileProperty.getValue());
-
-                String decodedString = new String(decoded);
-                JsonObject jsonObject = JsonParser.parseString(decodedString).getAsJsonObject();
-                String decodedSkin = jsonObject.getAsJsonObject().get("textures").getAsJsonObject().get("SKIN").getAsJsonObject().get("url").toString();
-                long timestamp = Long.parseLong(jsonObject.getAsJsonObject().get("timestamp").toString());
-                String requestDate = new java.text.SimpleDateFormat("MM/dd/yyyy HH:mm:ss").format(new java.util.Date(timestamp));
-
-                source.sendMessage(plugin.parseMessage("§aRequest time: §e" + requestDate));
-                source.sendMessage(plugin.parseMessage("§aprofileId: §e" + jsonObject.getAsJsonObject().get("profileId").toString()));
-                source.sendMessage(plugin.parseMessage("§aName: §e" + jsonObject.getAsJsonObject().get("profileName").toString()));
-                source.sendMessage(plugin.parseMessage("§aSkinTexture: §e" + decodedSkin.substring(1, decodedSkin.length() - 1)));
-                source.sendMessage(plugin.parseMessage("§cMore info in console!"));
-
-                // Console
-                logger.info("§aName: §8" + profileProperty.getName());
-                logger.info("§aValue : §8" + profileProperty.getValue());
-                logger.info("§aSignature : §8" + profileProperty.getSignature());
-                logger.info("§aValue Decoded: §e" + Arrays.toString(decoded));
-            });
-        });
+        onProps(wrapCommandSender(source), wrapPlayer(target.getPlayer()));
     }
 
     @Subcommand("applyskin")
@@ -169,16 +83,7 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("%helpSrApplySkin")
     @Syntax(" <target>")
     public void onApplySkin(CommandSource source, @Single OnlinePlayer target) {
-        Sponge.getScheduler().createAsyncExecutor(plugin).execute(() -> {
-            try {
-                final String skin = plugin.getSkinStorage().getDefaultSkinName(target.getPlayer().getName());
-
-                plugin.getSkinApplierSponge().updateProfileSkin(target.getPlayer().getProfile(), skin);
-                source.sendMessage(plugin.parseMessage("success: player skin has been refreshed!"));
-            } catch (SkinRequestException ignored) {
-                source.sendMessage(plugin.parseMessage("ERROR: player skin could NOT be refreshed!"));
-            }
-        });
+        onApplySkin(wrapCommandSender(source), wrapPlayer(target.getPlayer()));
     }
 
     @Subcommand("createcustom")
@@ -187,19 +92,7 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("%helpSrCreateCustom")
     @Syntax(" <skinName> <skinUrl> [steve/slim]")
     public void onCreateCustom(CommandSource source, String name, String skinUrl, @Optional SkinType skinType) {
-        Sponge.getScheduler().createAsyncExecutor(plugin).execute(() -> {
-            try {
-                if (C.validUrl(skinUrl)) {
-                    plugin.getSkinStorage().setSkinData(name, plugin.getMineSkinAPI().genSkin(skinUrl, String.valueOf(skinType), null),
-                            System.currentTimeMillis() + (100L * 365 * 24 * 60 * 60 * 1000)); // "generate" and save skin for 100 years
-                    source.sendMessage(plugin.parseMessage(Locale.SUCCESS_CREATE_SKIN.replace("%skin", name)));
-                } else {
-                    source.sendMessage(plugin.parseMessage(Locale.ERROR_INVALID_URLSKIN));
-                }
-            } catch (SkinRequestException e) {
-                source.sendMessage(plugin.parseMessage(e.getMessage()));
-            }
-        });
+        onCreateCustom(wrapCommandSender(source), name, skinUrl, skinType);
     }
 
     @Subcommand("setskinall")
@@ -207,45 +100,16 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("Set the skin to evey player")
     @Syntax(" <Skin / Url> [steve/slim]")
     public void onSetSkinAll(CommandSource source, String skin, @Optional SkinType skinType) {
-        Sponge.getScheduler().createAsyncExecutor(plugin).execute(() -> {
-            if (source != Sponge.getServer().getConsole()) {
-                source.sendMessage(plugin.parseMessage(Locale.PREFIX + "&4Only console may execute this command!"));
-            }
-
-            String skinName = " ·setSkinAll";
-            try {
-                IProperty skinProps = null;
-                if (C.validUrl(skin)) {
-                    skinProps = plugin.getMineSkinAPI().genSkin(skin, String.valueOf(skinType), null);
-                } else {
-                    skinProps = plugin.getMojangAPI().getSkin(skin).orElse(null);
-                }
-                if (skinProps == null) {
-                    source.sendMessage(plugin.parseMessage(Locale.PREFIX + ("&4no skin found....")));
-                    return;
-                }
-
-                plugin.getSkinStorage().setSkinData(skinName, skinProps);
-                for (Player player : Sponge.getServer().getOnlinePlayers()) {
-                    String pName = player.getName();
-                    plugin.getSkinStorage().setSkinName(pName, skinName); // set player to "whitespaced" name then reload skin
-                    plugin.getSkinsRestorerAPI().applySkin(new PlayerWrapper(player), skinProps);
-                }
-            } catch (SkinRequestException e) {
-                source.sendMessage(plugin.parseMessage(e.getMessage()));
-            }
-        });
+        onSetSkinAll(wrapCommandSender(source), skin, skinType);
     }
 
-    @SuppressWarnings("unused")
-    public enum PlayerOrSkin {
-        PLAYER,
-        SKIN,
+    @Override
+    public String getPlatformVersion() {
+        return plugin.getGame().getPlatform().getMinecraftVersion().getName();
     }
 
-    @SuppressWarnings("unused")
-    public enum SkinType {
-        STEVE,
-        SLIM,
+    @Override
+    public String getProxyMode() {
+        return "Sponge-Plugin";
     }
 }

--- a/sponge/src/main/java/net/skinsrestorer/sponge/commands/SrCommand.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/commands/SrCommand.java
@@ -25,6 +25,7 @@ import co.aikar.commands.annotation.*;
 import co.aikar.commands.sponge.contexts.OnlinePlayer;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.api.SkinVariant;
 import net.skinsrestorer.api.interfaces.ISRPlayer;
 import net.skinsrestorer.api.property.GenericProperty;
 import net.skinsrestorer.api.property.IProperty;
@@ -99,17 +100,17 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @CommandPermission("%srCreateCustom")
     @CommandCompletion("@skinName @skinUrl")
     @Description("%helpSrCreateCustom")
-    @Syntax(" <skinName> <skinUrl> [steve/slim]")
-    public void onCreateCustom(CommandSource source, String name, String skinUrl, @Optional SkinType skinType) {
-        onCreateCustom(wrapCommandSender(source), name, skinUrl, skinType);
+    @Syntax(" <skinName> <skinUrl> [classic/slim]")
+    public void onCreateCustom(CommandSource source, String name, String skinUrl, @Optional SkinVariant skinVariant) {
+        onCreateCustom(wrapCommandSender(source), name, skinUrl, skinVariant);
     }
 
     @Subcommand("setskinall")
     @CommandCompletion("@Skin")
     @Description("Set the skin to evey player")
-    @Syntax(" <Skin / Url> [steve/slim]")
-    public void onSetSkinAll(CommandSource source, String skin, @Optional SkinType skinType) {
-        onSetSkinAll(wrapCommandSender(source), skin, skinType);
+    @Syntax(" <Skin / Url> [classic/slim]")
+    public void onSetSkinAll(CommandSource source, String skin, @Optional SkinVariant skinVariant) {
+        onSetSkinAll(wrapCommandSender(source), skin, skinVariant);
     }
 
     @Override

--- a/sponge/src/main/java/net/skinsrestorer/sponge/utils/WrapperSponge.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/utils/WrapperSponge.java
@@ -23,6 +23,7 @@ import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.interfaces.ISRCommandSender;
 import net.skinsrestorer.api.interfaces.ISRPlayer;
 import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.source.ConsoleSource;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
 
@@ -42,6 +43,11 @@ public class WrapperSponge {
             @Override
             public boolean hasPermission(String permission) {
                 return sender.hasPermission(permission);
+            }
+
+            @Override
+            public boolean isConsole() {
+                return sender instanceof ConsoleSource;
             }
         };
     }

--- a/sponge/src/main/java/net/skinsrestorer/sponge/utils/WrapperSponge.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/utils/WrapperSponge.java
@@ -1,0 +1,72 @@
+/*
+ * SkinsRestorer
+ *
+ * Copyright (C) 2022 SkinsRestorer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ */
+package net.skinsrestorer.sponge.utils;
+
+import net.skinsrestorer.api.PlayerWrapper;
+import net.skinsrestorer.api.interfaces.ISRCommandSender;
+import net.skinsrestorer.api.interfaces.ISRPlayer;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.text.Text;
+
+public class WrapperSponge {
+    public static ISRCommandSender wrapCommandSender(CommandSource sender) {
+        return new ISRCommandSender() {
+            @Override
+            public void sendMessage(String message) {
+                sender.sendMessage(Text.builder(message).build());
+            }
+
+            @Override
+            public String getName() {
+                return sender.getName();
+            }
+
+            @Override
+            public boolean hasPermission(String permission) {
+                return sender.hasPermission(permission);
+            }
+        };
+    }
+
+    public static ISRPlayer wrapPlayer(Player player) {
+        return new ISRPlayer() {
+            @Override
+            public PlayerWrapper getWrapper() {
+                return new PlayerWrapper(player);
+            }
+
+            @Override
+            public String getName() {
+                return player.getName();
+            }
+
+            @Override
+            public void sendMessage(String message) {
+                player.sendMessage(Text.builder(message).build());
+            }
+
+            @Override
+            public boolean hasPermission(String permission) {
+                return player.hasPermission(permission);
+            }
+        };
+    }
+}

--- a/velocity/src/main/java/net/skinsrestorer/velocity/SkinsRestorer.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/SkinsRestorer.java
@@ -30,8 +30,6 @@ import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import lombok.Getter;
-import net.kyori.adventure.text.TextComponent;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.SkinsRestorerAPI;
 import net.skinsrestorer.api.exception.SkinRequestException;
@@ -64,16 +62,15 @@ import org.slf4j.Logger;
 import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Random;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 @Getter
 @Plugin(id = "skinsrestorer", name = "SkinsRestorer", version = BuildData.VERSION, description = BuildData.DESCRIPTION, url = BuildData.URL, authors = {"Blackfire62", "McLive"})
 public class SkinsRestorer implements ISRPlugin {
     private final ProxyServer proxy;
-    private final ExecutorService service = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
     private final Metrics.Factory metricsFactory;
     private final MetricsCounter metricsCounter = new MetricsCounter();
     private final File dataFolder;
@@ -150,7 +147,7 @@ public class SkinsRestorer implements ISRPlugin {
         prepareACF(manager, srLogger);
 
         manager.registerCommand(new SkinCommand(this));
-        manager.registerCommand(new SrCommand(this, srLogger, this.proxy));
+        manager.registerCommand(new SrCommand(this));
     }
 
     private boolean initStorage() {
@@ -158,7 +155,7 @@ public class SkinsRestorer implements ISRPlugin {
         if (!SharedMethods.initMysql(srLogger, skinStorage, dataFolder)) return false;
 
         // Preload default skins
-        getService().execute(skinStorage::preloadDefaultSkins);
+        runAsync(skinStorage::preloadDefaultSkins);
         return true;
     }
 
@@ -167,7 +164,7 @@ public class SkinsRestorer implements ISRPlugin {
     }
 
     private void checkUpdate(boolean showUpToDate) {
-        getService().execute(() -> updateChecker.checkForUpdate(new UpdateCallback() {
+        runAsync(() -> updateChecker.checkForUpdate(new UpdateCallback() {
             @Override
             public void updateAvailable(String newVersion, String downloadUrl, boolean hasDirectDownload) {
                 updateChecker.getUpdateAvailableMessages(newVersion, downloadUrl, hasDirectDownload, getVersion(), false)
@@ -183,10 +180,6 @@ public class SkinsRestorer implements ISRPlugin {
         }));
     }
 
-    public TextComponent deserialize(String string) {
-        return LegacyComponentSerializer.legacySection().deserialize(string);
-    }
-
     @Override
     public String getVersion() {
         return container.getDescription().getVersion().orElse("Unknown");
@@ -195,6 +188,16 @@ public class SkinsRestorer implements ISRPlugin {
     @Override
     public InputStream getResource(String resource) {
         return getClass().getClassLoader().getResourceAsStream(resource);
+    }
+
+    @Override
+    public void runAsync(Runnable runnable) {
+        proxy.getScheduler().buildTask(this, runnable).schedule();
+    }
+
+    @Override
+    public Collection<ISRPlayer> getOnlinePlayers() {
+        return proxy.getAllPlayers().stream().map(WrapperVelocity::wrapPlayer).collect(Collectors.toList());
     }
 
     private static class WrapperFactoryVelocity extends WrapperFactory {

--- a/velocity/src/main/java/net/skinsrestorer/velocity/SkinsRestorer.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/SkinsRestorer.java
@@ -148,7 +148,7 @@ public class SkinsRestorer implements ISRPlugin {
 
         prepareACF(manager, srLogger);
 
-        manager.registerCommand(new SkinCommand(this, srLogger));
+        manager.registerCommand(new SkinCommand(this));
         manager.registerCommand(new SrCommand(this, srLogger, this.proxy));
     }
 

--- a/velocity/src/main/java/net/skinsrestorer/velocity/SkinsRestorer.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/SkinsRestorer.java
@@ -55,6 +55,7 @@ import net.skinsrestorer.shared.utils.log.Slf4LoggerImpl;
 import net.skinsrestorer.velocity.command.SkinCommand;
 import net.skinsrestorer.velocity.command.SrCommand;
 import net.skinsrestorer.velocity.listener.GameProfileRequest;
+import net.skinsrestorer.velocity.utils.WrapperVelocity;
 import org.bstats.charts.SingleLineChart;
 import org.bstats.velocity.Metrics;
 import org.inventivetalent.update.spiget.UpdateCallback;
@@ -198,26 +199,11 @@ public class SkinsRestorer implements ISRPlugin {
 
     private static class WrapperFactoryVelocity extends WrapperFactory {
         @Override
-        public ISRPlayer wrap(Object playerInstance) {
+        public ISRPlayer wrapPlayer(Object playerInstance) {
             if (playerInstance instanceof Player) {
                 Player player = (Player) playerInstance;
 
-                return new ISRPlayer() {
-                    @Override
-                    public PlayerWrapper getWrapper() {
-                        return new PlayerWrapper(playerInstance);
-                    }
-
-                    @Override
-                    public String getName() {
-                        return player.getUsername();
-                    }
-
-                    @Override
-                    public void sendMessage(String message) {
-                        player.sendMessage(LegacyComponentSerializer.legacySection().deserialize(message));
-                    }
-                };
+                return WrapperVelocity.wrapPlayer(player);
             } else {
                 throw new IllegalArgumentException("Player instance is not valid!");
             }

--- a/velocity/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
@@ -32,16 +32,12 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.interfaces.ISRCommandSender;
-import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.shared.commands.ISkinCommand;
 import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.storage.CooldownStorage;
 import net.skinsrestorer.shared.storage.Locale;
 import net.skinsrestorer.shared.utils.C;
-import net.skinsrestorer.shared.utils.log.SRLogger;
 import net.skinsrestorer.velocity.SkinsRestorer;
-
-import java.util.concurrent.TimeUnit;
 
 // TODO: update deprecated CommandSource#sendMessage() for velocity
 @RequiredArgsConstructor
@@ -198,7 +194,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
                 }
             }
 
-            if (setSkin(wrap(source), new PlayerWrapper(player), skin, true, false, skinType) && (source != player)) {
+            if (setSkin(wrapped, new PlayerWrapper(player), skin, true, false, skinType) && (source != player)) {
                 source.sendMessage(LegacyComponentSerializer.legacySection().deserialize(Locale.ADMIN_SET_SKIN.replace("%player", player.getUsername())));
             }
         });
@@ -219,92 +215,9 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
         onSkinSetOther(player, new OnlinePlayer(player), url, skinType);
     }
 
-    // if save is false, we won't save the skin skin name
-    // because default skin names shouldn't be saved as the users custom skin
-    private boolean setSkin(ISRCommandSender source, PlayerWrapper player, String skin, boolean save, boolean clear, SkinType skinType) {
-        if (skin.equalsIgnoreCase("null")) {
-            source.sendMessage(Locale.INVALID_PLAYER.replace("%player", skin));
-            return false;
-        }
-
-        if (Config.DISABLED_SKINS_ENABLED && !clear && !source.hasPermission("skinsrestorer.bypassdisabled")) {
-            for (String dskin : Config.DISABLED_SKINS)
-                if (skin.equalsIgnoreCase(dskin)) {
-                    source.sendMessage(Locale.SKIN_DISABLED);
-                    return false;
-                }
-        }
-
-        final String senderName = source.getName();
-        if (!source.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(senderName)) {
-            source.sendMessage(Locale.SKIN_COOLDOWN.replace("%s", "" + CooldownStorage.getCooldown(senderName)));
-            return false;
-        }
-
-        CooldownStorage.setCooldown(senderName, Config.SKIN_CHANGE_COOLDOWN, TimeUnit.SECONDS);
-
-        final String pName = player.getName();
-        final java.util.Optional<String> oldSkinName = plugin.getSkinStorage().getSkinName(pName);
-        if (C.validUrl(skin)) {
-            if (!source.hasPermission("skinsrestorer.command.set.url")
-                    && !Config.SKIN_WITHOUT_PERM
-                    && !clear) {//ignore /skin clear when defaultSkin = url
-                source.sendMessage(Locale.PLAYER_HAS_NO_PERMISSION_URL);
-                CooldownStorage.resetCooldown(senderName);
-                return false;
-            }
-
-            if (!C.allowedSkinUrl(skin)) {
-                source.sendMessage(Locale.SKINURL_DISALLOWED);
-                CooldownStorage.resetCooldown(senderName);
-                return false;
-            }
-
-            try {
-                source.sendMessage(Locale.MS_UPDATING_SKIN);
-                String skinentry = " " + pName; // so won't overwrite premium playernames
-                if (skinentry.length() > 16) // max len of 16 char
-                    skinentry = skinentry.substring(0, 16);
-
-                IProperty generatedSkin = plugin.getMineSkinAPI().genSkin(skin, String.valueOf(skinType), null);
-                plugin.getSkinStorage().setSkinData(skinentry, generatedSkin,
-                        System.currentTimeMillis() + (100L * 365 * 24 * 60 * 60 * 1000)); // "generate" and save skin for 100 years
-                plugin.getSkinStorage().setSkinName(pName, skinentry); // set player to "whitespaced" name then reload skin
-                plugin.getSkinsRestorerAPI().applySkin(player, generatedSkin);
-                if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
-                    player.sendMessage(Locale.SKIN_CHANGE_SUCCESS.replace("%skin", "skinUrl"));
-                return true;
-            } catch (SkinRequestException e) {
-                source.sendMessage(e.getMessage());
-            } catch (Exception e) {
-                e.printStackTrace();
-                source.sendMessage(Locale.INVALID_PLAYER.replace("%player", skin));
-            }
-            // set CoolDown to ERROR_COOLDOWN and rollback to old skin on exception
-        } else {
-            try {
-                if (save)
-                    plugin.getSkinStorage().setSkinName(pName, skin);
-                plugin.getSkinsRestorerAPI().applySkin(player);
-                if (!Locale.SKIN_CHANGE_SUCCESS.isEmpty() && !Locale.SKIN_CHANGE_SUCCESS.equals(Locale.PREFIX))
-                    player.sendMessage(Locale.SKIN_CHANGE_SUCCESS.replace("%skin", skin));
-                return true;
-            } catch (SkinRequestException e) {
-                if (clear) {
-                    plugin.getSkinsRestorerAPI().applySkin(player, plugin.getMojangAPI().createProperty("textures", "", ""));
-                    return true;
-                }
-                source.sendMessage(e.getMessage());
-                // set custom skin name back to old one if there is an exception
-            } catch (Exception e) {
-                e.printStackTrace();
-                source.sendMessage(Locale.INVALID_PLAYER.replace("%player", skin));
-            }
-        }
-        // set CoolDown to ERROR_COOLDOWN and rollback to old skin on exception
-        CooldownStorage.setCooldown(senderName, Config.SKIN_ERROR_COOLDOWN, TimeUnit.SECONDS);
-        rollback(pName, oldSkinName.orElse(pName), save);
-        return false;
+    @Override
+    public void clearSkin(PlayerWrapper player) {
+        plugin.getSkinsRestorerAPI().applySkin(player, emptySkin);
     }
 
     private String getSenderName(CommandSource source) {

--- a/velocity/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
@@ -32,6 +32,7 @@ import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.interfaces.ISRCommandSender;
 import net.skinsrestorer.api.property.IProperty;
+import net.skinsrestorer.shared.commands.ISkinCommand;
 import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.storage.CooldownStorage;
 import net.skinsrestorer.shared.storage.Locale;
@@ -46,7 +47,7 @@ import java.util.concurrent.TimeUnit;
 @SuppressWarnings("deprecation")
 @CommandAlias("skin")
 @CommandPermission("%skin")
-public class SkinCommand extends BaseCommand {
+public class SkinCommand extends BaseCommand implements ISkinCommand {
     private final SkinsRestorer plugin;
     private final SRLogger log;
 

--- a/velocity/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
@@ -27,8 +27,8 @@ import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.SkinVariant;
+import net.skinsrestorer.api.interfaces.ISRPlayer;
 import net.skinsrestorer.shared.commands.ISkinCommand;
 import net.skinsrestorer.velocity.SkinsRestorer;
 
@@ -123,8 +123,8 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     }
 
     @Override
-    public void clearSkin(PlayerWrapper player) {
-        plugin.getSkinsRestorerAPI().applySkin(player, emptySkin);
+    public void clearSkin(ISRPlayer player) {
+        plugin.getSkinsRestorerAPI().applySkin(player.getWrapper(), emptySkin);
     }
 
 }

--- a/velocity/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
@@ -126,8 +126,4 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
         plugin.getSkinsRestorerAPI().applySkin(player, emptySkin);
     }
 
-    @Override
-    public void runAsync(Runnable runnable) {
-        plugin.getService().execute(runnable);
-    }
 }

--- a/velocity/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
@@ -28,6 +28,7 @@ import com.velocitypowered.api.proxy.Player;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import net.skinsrestorer.api.PlayerWrapper;
+import net.skinsrestorer.api.SkinVariant;
 import net.skinsrestorer.shared.commands.ISkinCommand;
 import net.skinsrestorer.velocity.SkinsRestorer;
 
@@ -108,8 +109,8 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @CommandCompletion("@players @skin")
     @Description("%helpSkinSetOther")
     @Syntax("%SyntaxSkinSetOther")
-    public void onSkinSetOther(CommandSource source, OnlinePlayer target, String skin, @Optional SkinType skinType) {
-        onSkinSetOther(wrapCommandSender(source), wrapPlayer(target.getPlayer()), skin, skinType);
+    public void onSkinSetOther(CommandSource source, OnlinePlayer target, String skin, @Optional SkinVariant skinVariant) {
+        onSkinSetOther(wrapCommandSender(source), wrapPlayer(target.getPlayer()), skin, skinVariant);
     }
 
     @Subcommand("url")
@@ -117,8 +118,8 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @CommandCompletion("@skinUrl")
     @Description("%helpSkinSetUrl")
     @Syntax("%SyntaxSkinUrl")
-    public void onSkinSetUrl(Player player, String url, @Optional SkinType skinType) {
-        onSkinSetUrl(wrapPlayer(player), url, skinType);
+    public void onSkinSetUrl(Player player, String url, @Optional SkinVariant skinVariant) {
+        onSkinSetUrl(wrapPlayer(player), url, skinVariant);
     }
 
     @Override

--- a/velocity/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/command/SkinCommand.java
@@ -88,7 +88,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Description("%helpSkinClearOther")
     public void onSkinClearOther(CommandSource source, @Single OnlinePlayer target) {
         ISRCommandSender wrapped = wrap(source);
-        plugin.getService().execute(() -> {
+        runAsync(() -> {
             if (!source.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(getSenderName(source))) {
                 source.sendMessage(plugin.deserialize(Locale.SKIN_COOLDOWN.replace("%s", "" + CooldownStorage.getCooldown(getSenderName(source)))));
                 return;
@@ -126,7 +126,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Syntax("%SyntaxSkinUpdateOther")
     public void onSkinUpdateOther(CommandSource source, @Single OnlinePlayer target) {
         ISRCommandSender wrapped = wrap(source);
-        plugin.getService().execute(() -> {
+        runAsync(() -> {
             if (!source.hasPermission("skinsrestorer.bypasscooldown") && CooldownStorage.hasCooldown(getSenderName(source))) {
                 source.sendMessage(plugin.deserialize(Locale.SKIN_COOLDOWN.replace("%s", "" + CooldownStorage.getCooldown(getSenderName(source)))));
                 return;
@@ -157,7 +157,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
                 return;
             }
 
-            if (setSkin(wrap(source), new PlayerWrapper(player), skin.get(), false, false, null)) {
+            if (setSkin(wrapped, new PlayerWrapper(player), skin.get(), false, false, null)) {
                 if (source == player)
                     source.sendMessage(plugin.deserialize(Locale.SUCCESS_UPDATING_SKIN));
                 else
@@ -185,7 +185,7 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Syntax("%SyntaxSkinSetOther")
     public void onSkinSetOther(CommandSource source, OnlinePlayer target, String skin, @Optional SkinType skinType) {
         ISRCommandSender wrapped = wrap(source);
-        plugin.getService().execute(() -> {
+        runAsync(() -> {
             final Player player = target.getPlayer();
             if (Config.PER_SKIN_PERMISSIONS && !source.hasPermission("skinsrestorer.skin." + skin)) {
                 if (!source.hasPermission("skinsrestorer.ownskin") && !getSenderName(source).equalsIgnoreCase(player.getUsername()) || !skin.equalsIgnoreCase(getSenderName(source))) {
@@ -218,6 +218,11 @@ public class SkinCommand extends BaseCommand implements ISkinCommand {
     @Override
     public void clearSkin(PlayerWrapper player) {
         plugin.getSkinsRestorerAPI().applySkin(player, emptySkin);
+    }
+
+    @Override
+    public void runAsync(Runnable runnable) {
+        plugin.getService().execute(runnable);
     }
 
     private String getSenderName(CommandSource source) {

--- a/velocity/src/main/java/net/skinsrestorer/velocity/command/SrCommand.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/command/SrCommand.java
@@ -33,6 +33,7 @@ import lombok.RequiredArgsConstructor;
 import net.skinsrestorer.api.PlayerWrapper;
 import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.property.IProperty;
+import net.skinsrestorer.shared.commands.ISRCommand;
 import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.storage.Locale;
 import net.skinsrestorer.shared.utils.C;
@@ -47,7 +48,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @CommandAlias("sr|skinsrestorer")
 @CommandPermission("%sr")
-public class SrCommand extends BaseCommand {
+public class SrCommand extends BaseCommand implements ISRCommand {
     private final SkinsRestorer plugin;
     private final SRLogger logger;
     private final ProxyServer proxy;

--- a/velocity/src/main/java/net/skinsrestorer/velocity/command/SrCommand.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/command/SrCommand.java
@@ -25,10 +25,17 @@ import co.aikar.commands.annotation.*;
 import co.aikar.commands.velocity.contexts.OnlinePlayer;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.util.GameProfile;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.api.interfaces.ISRPlayer;
+import net.skinsrestorer.api.property.GenericProperty;
+import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.shared.commands.ISRCommand;
 import net.skinsrestorer.velocity.SkinsRestorer;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static net.skinsrestorer.velocity.utils.WrapperVelocity.wrapCommandSender;
 import static net.skinsrestorer.velocity.utils.WrapperVelocity.wrapPlayer;
@@ -104,10 +111,6 @@ public class SrCommand extends BaseCommand implements ISRCommand {
         onSetSkinAll(wrapCommandSender(source), skin, skinType);
     }
 
-    private String getSenderName(CommandSource source) {
-        return source instanceof Player ? ((Player) source).getUsername() : "CONSOLE";
-    }
-
     @Override
     public String getPlatformVersion() {
         return plugin.getProxy().getVersion().getVersion();
@@ -116,5 +119,16 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Override
     public String getProxyMode() {
         return "Velocity-Plugin";
+    }
+
+    @Override
+    public List<IProperty> getPropertiesOfPlayer(ISRPlayer player) {
+        List<GameProfile.Property> prop = player.getWrapper().get(Player.class).getGameProfileProperties();
+
+        if (prop == null) {
+            return null;
+        }
+
+        return prop.stream().map(property -> new GenericProperty(property.getName(), property.getValue(), property.getSignature())).collect(Collectors.toList());
     }
 }

--- a/velocity/src/main/java/net/skinsrestorer/velocity/command/SrCommand.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/command/SrCommand.java
@@ -23,87 +23,41 @@ import co.aikar.commands.BaseCommand;
 import co.aikar.commands.CommandHelp;
 import co.aikar.commands.annotation.*;
 import co.aikar.commands.velocity.contexts.OnlinePlayer;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
-import com.velocitypowered.api.proxy.ProxyServer;
-import com.velocitypowered.api.util.GameProfile;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.skinsrestorer.api.PlayerWrapper;
-import net.skinsrestorer.api.exception.SkinRequestException;
-import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.shared.commands.ISRCommand;
-import net.skinsrestorer.shared.storage.Config;
-import net.skinsrestorer.shared.storage.Locale;
-import net.skinsrestorer.shared.utils.C;
-import net.skinsrestorer.shared.utils.connections.ServiceChecker;
-import net.skinsrestorer.shared.utils.log.SRLogger;
 import net.skinsrestorer.velocity.SkinsRestorer;
 
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.List;
+import static net.skinsrestorer.velocity.utils.WrapperVelocity.wrapCommandSender;
+import static net.skinsrestorer.velocity.utils.WrapperVelocity.wrapPlayer;
 
 @RequiredArgsConstructor
 @CommandAlias("sr|skinsrestorer")
 @CommandPermission("%sr")
 public class SrCommand extends BaseCommand implements ISRCommand {
+    @Getter
     private final SkinsRestorer plugin;
-    private final SRLogger logger;
-    private final ProxyServer proxy;
 
     @HelpCommand
     @Syntax(" [help]")
     public void onHelp(CommandSource source, CommandHelp help) {
-        help.showHelp();
+        onHelp(wrapCommandSender(source), help);
     }
 
     @Subcommand("reload")
     @CommandPermission("%srReload")
     @Description("%helpSrReload")
     public void onReload(CommandSource source) {
-        Locale.load(plugin.getDataFolder(), logger);
-        Config.load(plugin.getDataFolder(), plugin.getClass().getClassLoader().getResourceAsStream("config.yml"), logger);
-
-        plugin.prepareACF(plugin.getManager(), plugin.getSrLogger());
-
-        source.sendMessage(plugin.deserialize(Locale.RELOAD));
+        onReload(wrapCommandSender(source));
     }
 
     @Subcommand("status")
     @CommandPermission("%srStatus")
     @Description("%helpSrStatus")
     public void onStatus(CommandSource source) {
-        plugin.getService().execute(() -> {
-            source.sendMessage(plugin.deserialize("§3----------------------------------------------"));
-            source.sendMessage(plugin.deserialize("§7Checking needed services for SR to work properly..."));
-
-            ServiceChecker checker = new ServiceChecker();
-            checker.setMojangAPI(plugin.getMojangAPI());
-            checker.checkServices();
-
-            ServiceChecker.ServiceCheckResponse response = checker.getResponse();
-            List<String> results = response.getResults();
-
-            if (Config.DEBUG || !(response.getWorkingUUID().get() >= 1) || !(response.getWorkingProfile().get() >= 1))
-                for (String result : results) {
-                    if (Config.DEBUG || result.contains("✘"))
-                        source.sendMessage(plugin.deserialize(result));
-                }
-            source.sendMessage(plugin.deserialize("§7Working UUID API count: §6" + response.getWorkingUUID()));
-            source.sendMessage(plugin.deserialize("§7Working Profile API count: §6" + response.getWorkingProfile()));
-            if (response.getWorkingUUID().get() >= 1 && response.getWorkingProfile().get() >= 1)
-                source.sendMessage(plugin.deserialize("§aThe plugin currently is in a working state."));
-            else
-                source.sendMessage(plugin.deserialize("§cPlugin currently can't fetch new skins. \\n Connection is likely blocked because of firewall. \\n Please See https://skinsrestorer.net/firewall for more info"));
-            source.sendMessage(plugin.deserialize("§3----------------------------------------------"));
-            source.sendMessage(plugin.deserialize("§7SkinsRestorer §6v" + plugin.getVersion()));
-            source.sendMessage(plugin.deserialize("§7Server: §6" + plugin.getProxy().getVersion()));
-            source.sendMessage(plugin.deserialize("§7BungeeMode: §6Velocity-Plugin"));
-            source.sendMessage(plugin.deserialize("§7Finished checking services."));
-            source.sendMessage(plugin.deserialize("§3----------------------------------------------"));
-        });
+        onStatus(wrapCommandSender(source));
     }
 
     @Subcommand("drop|remove")
@@ -112,16 +66,7 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("%helpSrDrop")
     @Syntax(" <player|skin> <target> [target2]")
     public void onDrop(CommandSource source, PlayerOrSkin playerOrSkin, String[] targets) {
-        plugin.getService().execute(() -> {
-            if (playerOrSkin == PlayerOrSkin.PLAYER)
-                for (String targetPlayer : targets)
-                    plugin.getSkinStorage().removeSkin(targetPlayer);
-            else
-                for (String targetSkin : targets)
-                    plugin.getSkinStorage().removeSkinData(targetSkin);
-            String targetList = Arrays.toString(targets).substring(1, Arrays.toString(targets).length() - 1);
-            source.sendMessage(plugin.deserialize(Locale.DATA_DROPPED.replace("%playerOrSkin", playerOrSkin.toString()).replace("%targets", targetList)));
-        });
+        onDrop(wrapCommandSender(source), playerOrSkin, targets);
     }
 
     @Subcommand("props")
@@ -130,33 +75,7 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("%helpSrProps")
     @Syntax(" <target>")
     public void onProps(CommandSource source, @Single OnlinePlayer target) {
-        plugin.getService().execute(() -> {
-            GameProfile.Property prop = target.getPlayer().getGameProfileProperties().get(0);
-
-            if (prop == null) {
-                source.sendMessage(plugin.deserialize(Locale.NO_SKIN_DATA));
-                return;
-            }
-            byte[] decoded = Base64.getDecoder().decode(prop.getValue());
-
-            String decodedString = new String(decoded);
-            JsonObject jsonObject = JsonParser.parseString(decodedString).getAsJsonObject();
-            String decodedSkin = jsonObject.getAsJsonObject().get("textures").getAsJsonObject().get("SKIN").getAsJsonObject().get("url").toString();
-            long timestamp = Long.parseLong(jsonObject.getAsJsonObject().get("timestamp").toString());
-            String requestDate = new java.text.SimpleDateFormat("MM/dd/yyyy HH:mm:ss").format(new java.util.Date(timestamp));
-
-            source.sendMessage(plugin.deserialize("§aRequest time: §e" + requestDate));
-            source.sendMessage(plugin.deserialize("§aProfileId: §e" + jsonObject.getAsJsonObject().get("profileId").toString()));
-            source.sendMessage(plugin.deserialize("§aName: §e" + jsonObject.getAsJsonObject().get("profileName").toString()));
-            source.sendMessage(plugin.deserialize("§aSkinTexture: §e" + decodedSkin.substring(1, decodedSkin.length() - 1)));
-            source.sendMessage(plugin.deserialize("§cMore info in console!"));
-
-            // Console
-            logger.info("§aName: §8" + prop.getName());
-            logger.info("§aValue : §8" + prop.getValue());
-            logger.info("§aSignature : §8" + prop.getSignature());
-            logger.info("§aValue Decoded: §e" + Arrays.toString(decoded));
-        });
+        onProps(wrapCommandSender(source), wrapPlayer(target.getPlayer()));
     }
 
     @Subcommand("applyskin")
@@ -165,14 +84,7 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("%helpSrApplySkin")
     @Syntax(" <target>")
     public void onApplySkin(CommandSource source, @Single OnlinePlayer target) {
-        plugin.getService().execute(() -> {
-            try {
-                plugin.getSkinsRestorerAPI().applySkin(new PlayerWrapper(target.getPlayer()));
-                source.sendMessage(plugin.deserialize("success: player skin has been refreshed!"));
-            } catch (Exception ignored) {
-                source.sendMessage(plugin.deserialize("ERROR: player skin could NOT be refreshed!"));
-            }
-        });
+        onApplySkin(wrapCommandSender(source), wrapPlayer(target.getPlayer()));
     }
 
     @Subcommand("createcustom")
@@ -181,19 +93,7 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("%helpSrCreateCustom")
     @Syntax(" <skinName> <skinUrl> [steve/slim]")
     public void onCreateCustom(CommandSource source, String skinName, String skinUrl, @Optional SkinType skinType) {
-        plugin.getService().execute(() -> {
-            try {
-                if (C.validUrl(skinUrl)) {
-                    plugin.getSkinStorage().setSkinData(skinName, plugin.getMineSkinAPI().genSkin(skinUrl, String.valueOf(skinType), null),
-                            System.currentTimeMillis() + (100L * 365 * 24 * 60 * 60 * 1000)); // "generate" and save skin for 100 years
-                    source.sendMessage(plugin.deserialize(Locale.SUCCESS_CREATE_SKIN.replace("%skin", skinName)));
-                } else {
-                    source.sendMessage(plugin.deserialize(Locale.ERROR_INVALID_URLSKIN));
-                }
-            } catch (SkinRequestException e) {
-                source.sendMessage(plugin.deserialize(e.getMessage()));
-            }
-        });
+        onCreateCustom(wrapCommandSender(source), skinName, skinUrl, skinType);
     }
 
     @Subcommand("setskinall")
@@ -201,50 +101,20 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @Description("Set the skin to evey player")
     @Syntax(" <Skin / Url> [steve/slim]")
     public void onSetSkinAll(CommandSource source, String skin, @Optional SkinType skinType) {
-        plugin.getService().execute(() -> {
-            if (!getSenderName(source).equals("CONSOLE")) {
-                source.sendMessage(plugin.deserialize(Locale.PREFIX + "&4Only console may execute this command!"));
-                return;
-            }
-
-            String skinName = " ·setSkinAll";
-            try {
-                IProperty skinProps = null;
-                if (C.validUrl(skin)) {
-                    skinProps = plugin.getMineSkinAPI().genSkin(skin, String.valueOf(skinType), null);
-                } else {
-                    skinProps = plugin.getMojangAPI().getSkin(skin).orElse(null);
-                }
-                if (skinProps == null) {
-                    source.sendMessage(plugin.deserialize(Locale.PREFIX + ("&4no skin found....")));
-                    return;
-                }
-
-                plugin.getSkinStorage().setSkinData(skinName, skinProps);
-                for (Player player : proxy.getAllPlayers()) {
-                    String pName = player.getUsername();
-                    plugin.getSkinStorage().setSkinName(pName, skinName); // set player to "whitespaced" name then reload skin
-                    plugin.getSkinsRestorerAPI().applySkin(new PlayerWrapper(player), skinProps);
-                }
-            } catch (SkinRequestException e) {
-                source.sendMessage(plugin.deserialize(e.getMessage()));
-            }
-        });
+        onSetSkinAll(wrapCommandSender(source), skin, skinType);
     }
 
     private String getSenderName(CommandSource source) {
         return source instanceof Player ? ((Player) source).getUsername() : "CONSOLE";
     }
 
-    @SuppressWarnings("unused")
-    public enum PlayerOrSkin {
-        PLAYER,
-        SKIN,
+    @Override
+    public String getPlatformVersion() {
+        return plugin.getProxy().getVersion().getVersion();
     }
 
-    @SuppressWarnings("unused")
-    public enum SkinType {
-        STEVE,
-        SLIM,
+    @Override
+    public String getProxyMode() {
+        return "Velocity-Plugin";
     }
 }

--- a/velocity/src/main/java/net/skinsrestorer/velocity/command/SrCommand.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/command/SrCommand.java
@@ -28,6 +28,7 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.util.GameProfile;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import net.skinsrestorer.api.SkinVariant;
 import net.skinsrestorer.api.interfaces.ISRPlayer;
 import net.skinsrestorer.api.property.GenericProperty;
 import net.skinsrestorer.api.property.IProperty;
@@ -98,17 +99,17 @@ public class SrCommand extends BaseCommand implements ISRCommand {
     @CommandPermission("%srCreateCustom")
     @CommandCompletion("@skinName @skinUrl")
     @Description("%helpSrCreateCustom")
-    @Syntax(" <skinName> <skinUrl> [steve/slim]")
-    public void onCreateCustom(CommandSource source, String skinName, String skinUrl, @Optional SkinType skinType) {
-        onCreateCustom(wrapCommandSender(source), skinName, skinUrl, skinType);
+    @Syntax(" <skinName> <skinUrl> [classic/slim]")
+    public void onCreateCustom(CommandSource source, String skinName, String skinUrl, @Optional SkinVariant skinVariant) {
+        onCreateCustom(wrapCommandSender(source), skinName, skinUrl, skinVariant);
     }
 
     @Subcommand("setskinall")
     @CommandCompletion("@Skin")
     @Description("Set the skin to evey player")
-    @Syntax(" <Skin / Url> [steve/slim]")
-    public void onSetSkinAll(CommandSource source, String skin, @Optional SkinType skinType) {
-        onSetSkinAll(wrapCommandSender(source), skin, skinType);
+    @Syntax(" <Skin / Url> [classic/slim]")
+    public void onSetSkinAll(CommandSource source, String skin, @Optional SkinVariant skinVariant) {
+        onSetSkinAll(wrapCommandSender(source), skin, skinVariant);
     }
 
     @Override

--- a/velocity/src/main/java/net/skinsrestorer/velocity/utils/WrapperVelocity.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/utils/WrapperVelocity.java
@@ -20,6 +20,7 @@
 package net.skinsrestorer.velocity.utils;
 
 import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.ConsoleCommandSource;
 import com.velocitypowered.api.proxy.Player;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import net.skinsrestorer.api.PlayerWrapper;
@@ -42,6 +43,11 @@ public class WrapperVelocity {
             @Override
             public boolean hasPermission(String permission) {
                 return sender.hasPermission(permission);
+            }
+
+            @Override
+            public boolean isConsole() {
+                return sender instanceof ConsoleCommandSource;
             }
         };
     }

--- a/velocity/src/main/java/net/skinsrestorer/velocity/utils/WrapperVelocity.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/utils/WrapperVelocity.java
@@ -1,0 +1,76 @@
+/*
+ * SkinsRestorer
+ *
+ * Copyright (C) 2022 SkinsRestorer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ */
+package net.skinsrestorer.velocity.utils;
+
+import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.Player;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.skinsrestorer.api.PlayerWrapper;
+import net.skinsrestorer.api.interfaces.ISRCommandSender;
+import net.skinsrestorer.api.interfaces.ISRPlayer;
+
+public class WrapperVelocity {
+    public static ISRCommandSender wrapCommandSender(CommandSource sender) {
+        return new ISRCommandSender() {
+            @Override
+            public void sendMessage(String message) {
+                sender.sendMessage(LegacyComponentSerializer.legacySection().deserialize(message));
+            }
+
+            @Override
+            public String getName() {
+                return getSenderName(sender);
+            }
+
+            @Override
+            public boolean hasPermission(String permission) {
+                return sender.hasPermission(permission);
+            }
+        };
+    }
+
+    public static ISRPlayer wrapPlayer(Player player) {
+        return new ISRPlayer() {
+            @Override
+            public PlayerWrapper getWrapper() {
+                return new PlayerWrapper(player);
+            }
+
+            @Override
+            public String getName() {
+                return player.getUsername();
+            }
+
+            @Override
+            public void sendMessage(String message) {
+                player.sendMessage(LegacyComponentSerializer.legacySection().deserialize(message));
+            }
+
+            @Override
+            public boolean hasPermission(String permission) {
+                return player.hasPermission(permission);
+            }
+        };
+    }
+
+    private static String getSenderName(CommandSource source) {
+        return source instanceof Player ? ((Player) source).getUsername() : "CONSOLE";
+    }
+}


### PR DESCRIPTION
In this pr:
- Unify /sr and /skin command
  - Everything we now change will also take effect on all implementations. so no "bungee" only commands.
  - This should remove all code inconsistencies in /skin and /sr
- Fixed SkinVariant in /skin url
  - changed `String skinType` to `SkinVariant skinVariant`
- Reuse code
- Universal skin property
  - added `public IProperty createProperty(String name, String value, String signature)` to `SkinsRestorerAPI`
- /sr props response will send when ready
- performance improvements 

todo:
- [x] check if String.format has been done right
- [x] Fix MineSkin variant
- [x] test: sender == player
- [x] add color's to static messages
- [x] ~~hook /skins plugin message channel to new commands.~~
- [ ] Update SkinsRestorerAPIExample
