### PR TITLE
Improve onjoin by Universal join event & skipping skin if player join's premium & has no skin set

### DIFF
--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinsRestorer.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/SkinsRestorer.java
@@ -277,7 +277,7 @@ public class SkinsRestorer extends JavaPlugin implements ISRPlugin {
 
         // Init listener
         if (!Config.ENABLE_PROTOCOL_LISTENER || Bukkit.getPluginManager().getPlugin("ProtocolLib") == null) {
-            Bukkit.getPluginManager().registerEvents(new PlayerJoin(this, srLogger), this);
+            Bukkit.getPluginManager().registerEvents(new PlayerJoin(this), this);
         } else {
             srLogger.info("Hooking into ProtocolLib for instant skins on join!");
             new ProtocolLibJoinListener(this);

--- a/bungee/src/main/java/net/skinsrestorer/bungee/SkinsRestorer.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/SkinsRestorer.java
@@ -34,6 +34,7 @@ import net.skinsrestorer.api.serverinfo.Platform;
 import net.skinsrestorer.bungee.commands.GUICommand;
 import net.skinsrestorer.bungee.commands.SkinCommand;
 import net.skinsrestorer.bungee.commands.SrCommand;
+import net.skinsrestorer.bungee.listeners.ConnectListener;
 import net.skinsrestorer.bungee.listeners.LoginListener;
 import net.skinsrestorer.bungee.listeners.PluginMessageListener;
 import net.skinsrestorer.bungee.utils.BungeeConsoleImpl;
@@ -116,7 +117,8 @@ public class SkinsRestorer extends Plugin implements ISRPlugin {
             return;
 
         // Init listener
-        getProxy().getPluginManager().registerListener(this, new LoginListener(this, srLogger));
+        getProxy().getPluginManager().registerListener(this, new LoginListener(this));
+        getProxy().getPluginManager().registerListener(this, new ConnectListener(this));
 
         // Init commands
         initCommands();

--- a/bungee/src/main/java/net/skinsrestorer/bungee/listeners/ConnectListener.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/listeners/ConnectListener.java
@@ -1,0 +1,50 @@
+/*
+ * SkinsRestorer
+ *
+ * Copyright (C) 2022 SkinsRestorer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ */
+package net.skinsrestorer.bungee.listeners;
+
+import lombok.RequiredArgsConstructor;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.ServerConnectEvent;
+import net.md_5.bungee.api.plugin.Listener;
+import net.md_5.bungee.event.EventHandler;
+import net.md_5.bungee.event.EventPriority;
+import net.skinsrestorer.bungee.SkinsRestorer;
+import net.skinsrestorer.shared.storage.Locale;
+
+@RequiredArgsConstructor
+public class ConnectListener implements Listener {
+	private final SkinsRestorer plugin;
+
+	@EventHandler(priority = EventPriority.HIGH)
+	public void onServerConnect(final ServerConnectEvent event) {
+		if (event.isCancelled())
+			return;
+
+		plugin.getProxy().getScheduler().runAsync(plugin, () -> {
+			if (plugin.isOutdated()) {
+				final ProxiedPlayer player = event.getPlayer();
+
+				if (player.hasPermission("skinsrestorer.admincommand"))
+					player.sendMessage(TextComponent.fromLegacyText(Locale.OUTDATED));
+			}
+		});
+	}
+}

--- a/bungee/src/main/java/net/skinsrestorer/bungee/listeners/LoginListener.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/listeners/LoginListener.java
@@ -19,78 +19,63 @@
  */
 package net.skinsrestorer.bungee.listeners;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.md_5.bungee.BungeeCord;
-import net.md_5.bungee.api.chat.TextComponent;
-import net.md_5.bungee.api.connection.PendingConnection;
-import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.event.LoginEvent;
-import net.md_5.bungee.api.event.ServerConnectEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.connection.InitialHandler;
 import net.md_5.bungee.event.EventHandler;
 import net.md_5.bungee.event.EventPriority;
 import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.bungee.SkinsRestorer;
-import net.skinsrestorer.shared.storage.Config;
-import net.skinsrestorer.shared.storage.Locale;
-import net.skinsrestorer.shared.utils.log.SRLogger;
-
-import java.util.Optional;
+import net.skinsrestorer.shared.listeners.LoginProfileEvent;
+import net.skinsrestorer.shared.listeners.LoginProfileListener;
 
 @RequiredArgsConstructor
-public class LoginListener implements Listener {
+@Getter
+public class LoginListener extends LoginProfileListener implements Listener {
     private final SkinsRestorer plugin;
-    private final SRLogger log;
-    private final boolean isOnlineMode = BungeeCord.getInstance().getConfig().isOnlineMode();
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onLogin(final LoginEvent event) {
-        if ((event.isCancelled() && Config.NO_SKIN_IF_LOGIN_CANCELED)
-                || Config.DISABLE_ON_JOIN_SKINS)
+        LoginProfileEvent profileEvent = wrap(event);
+        if (handleSync(profileEvent))
             return;
 
         event.registerIntent(plugin);
 
         plugin.getProxy().getScheduler().runAsync(plugin, () -> {
-            final PendingConnection connection = event.getConnection();
-            final String name = connection.getName();
-            Optional<String> skin = plugin.getSkinStorage().getSkinName(name);
-
-            // Skip players if: OnlineMode & enabled & no skinSet & DefaultSkins.premium false
-            if (isOnlineMode && !Config.ALWAYS_APPLY_PREMIUM && !skin.isPresent() && !Config.DEFAULT_SKINS_PREMIUM) {
-                event.completeIntent(plugin);
-                return;
-            }
-
-            // Get default skin if enabled
-            if (Config.DEFAULT_SKINS_ENABLED)
-                skin = Optional.ofNullable(plugin.getSkinStorage().getDefaultSkinName(name));
-
-            try {
-                // TODO: add default skinurl support
-                plugin.getSkinApplierBungee().applySkin(skin.orElse(name), (InitialHandler) connection);
-            } catch (SkinRequestException ignored) {
-            } catch (Exception e1) {
-                e1.printStackTrace();
-            }
+            handleAsync(profileEvent).ifPresent(name -> {
+                try {
+                    // TODO: add default skinurl support
+                    plugin.getSkinApplierBungee().applySkin(name, (InitialHandler) event.getConnection());
+                } catch (SkinRequestException e) {
+                    plugin.getSrLogger().debug(e);
+                } catch (Exception e2) {
+                    e2.printStackTrace();
+                }
+            });
 
             event.completeIntent(plugin);
         });
     }
 
-    @EventHandler(priority = EventPriority.HIGH)
-    public void onServerConnect(final ServerConnectEvent e) {
-        if (e.isCancelled())
-            return;
-
-        plugin.getProxy().getScheduler().runAsync(plugin, () -> {
-            if (plugin.isOutdated()) {
-                final ProxiedPlayer player = e.getPlayer();
-
-                if (player.hasPermission("skinsrestorer.admincommand"))
-                    player.sendMessage(TextComponent.fromLegacyText(Locale.OUTDATED));
+    private LoginProfileEvent wrap(LoginEvent event) {
+        return new LoginProfileEvent() {
+            @Override
+            public boolean isOnline() {
+                return event.getConnection().isOnlineMode();
             }
-        });
+
+            @Override
+            public String getPlayerName() {
+                return event.getConnection().getName();
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return event.isCancelled();
+            }
+        };
     }
 }

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
@@ -186,6 +186,8 @@ public interface ISkinCommand {
     default boolean setSkin(ISRCommandSender sender, ISRPlayer player, String skin, boolean save, boolean clear, SkinVariant skinVariant) {
         ISRPlugin plugin = getPlugin();
 
+        // Escape "null" skin, this did cause crash in the past for some waterfall instances
+        // TODO: resolve this in a different way
         if (skin.equalsIgnoreCase("null")) {
             sender.sendMessage(Locale.INVALID_PLAYER.replace("%player", skin));
             return false;

--- a/shared/src/main/java/net/skinsrestorer/shared/listeners/LoginProfileEvent.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/listeners/LoginProfileEvent.java
@@ -1,0 +1,28 @@
+/*
+ * SkinsRestorer
+ *
+ * Copyright (C) 2022 SkinsRestorer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ */
+package net.skinsrestorer.shared.listeners;
+
+public interface LoginProfileEvent {
+	boolean isOnline();
+
+	String getPlayerName();
+
+	boolean isCancelled();
+}

--- a/shared/src/main/java/net/skinsrestorer/shared/listeners/LoginProfileListener.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/listeners/LoginProfileListener.java
@@ -1,0 +1,50 @@
+/*
+ * SkinsRestorer
+ *
+ * Copyright (C) 2022 SkinsRestorer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ */
+package net.skinsrestorer.shared.listeners;
+
+import net.skinsrestorer.shared.interfaces.ISRPlugin;
+import net.skinsrestorer.shared.storage.Config;
+
+import java.util.Optional;
+
+public abstract class LoginProfileListener {
+	protected boolean handleSync(LoginProfileEvent event) {
+		return Config.DISABLE_ON_JOIN_SKINS || (Config.NO_SKIN_IF_LOGIN_CANCELED && event.isCancelled());
+	}
+
+	// TODO: add default skinurl support
+	protected Optional<String> handleAsync(LoginProfileEvent event) {
+		ISRPlugin plugin = getPlugin();
+		String playerName = event.getPlayerName();
+		Optional<String> skin = plugin.getSkinStorage().getSkinName(playerName);
+
+		// Skip players if: OnlineMode & enabled & no skinSet & DefaultSkins.premium false
+		if (event.isOnline() && !Config.ALWAYS_APPLY_PREMIUM && !skin.isPresent() && !Config.DEFAULT_SKINS_PREMIUM)
+			return Optional.empty();
+
+		// Get default skin if enabled
+		if (Config.DEFAULT_SKINS_ENABLED)
+			skin = Optional.ofNullable(plugin.getSkinStorage().getDefaultSkinName(playerName));
+
+		return Optional.of(skin.orElse(playerName));
+	}
+
+	protected abstract ISRPlugin getPlugin();
+}

--- a/shared/src/main/java/net/skinsrestorer/shared/listeners/LoginProfileListener.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/listeners/LoginProfileListener.java
@@ -35,8 +35,11 @@ public abstract class LoginProfileListener {
 		String playerName = event.getPlayerName();
 		Optional<String> skin = plugin.getSkinStorage().getSkinName(playerName);
 
-		// Skip players if: OnlineMode & enabled & no skinSet & DefaultSkins.premium false
-		if (event.isOnline() && !Config.ALWAYS_APPLY_PREMIUM && !skin.isPresent() && !Config.DEFAULT_SKINS_PREMIUM)
+		// Skip players if: OnlineMode & no skin set & enabled & DefaultSkins.premium false
+		if (event.isOnline()
+				&& !skin.isPresent()
+				&& !Config.ALWAYS_APPLY_PREMIUM
+				&& !Config.DEFAULT_SKINS_PREMIUM)
 			return Optional.empty();
 
 		// Get default skin if enabled

--- a/shared/src/main/java/net/skinsrestorer/shared/utils/log/SRLogger.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/utils/log/SRLogger.java
@@ -60,6 +60,14 @@ public class SRLogger {
         debug(SRLogLevel.INFO, message);
     }
 
+    public void debug(String message, Throwable thrown) {
+        debug(SRLogLevel.WARNING, message, thrown);
+    }
+
+    public void debug(Throwable thrown) {
+        debug(SRLogLevel.WARNING, "Received error", thrown);
+    }
+
     public void debug(SRLogLevel level, String message) {
         if (!Config.DEBUG)
             return;

--- a/sponge/src/main/java/net/skinsrestorer/sponge/SkinsRestorer.java
+++ b/sponge/src/main/java/net/skinsrestorer/sponge/SkinsRestorer.java
@@ -72,171 +72,169 @@ import java.util.stream.Collectors;
 @Getter
 @Plugin(id = "skinsrestorer", name = "SkinsRestorer", version = BuildData.VERSION, description = BuildData.DESCRIPTION, url = BuildData.URL, authors = {"Blackfire62", "McLive"})
 public class SkinsRestorer implements ISRPlugin {
-    private static final boolean BUNGEE_ENABLED = false;
-    private final Metrics metrics;
-    private final MetricsCounter metricsCounter = new MetricsCounter();
-    private final SkinApplierSponge skinApplierSponge = new SkinApplierSponge(this);
-    private final File dataFolder;
-    private final SRLogger srLogger;
-    private final MojangAPI mojangAPI;
-    private final SkinStorage skinStorage;
-    private final SkinsRestorerAPI skinsRestorerAPI;
-    private final MineSkinAPI mineSkinAPI;
-    @Inject
-    protected Game game;
-    private UpdateChecker updateChecker;
-    private SpongeCommandManager manager;
-    @Inject
-    private PluginContainer container;
+	private static final boolean BUNGEE_ENABLED = false;
+	private final Metrics metrics;
+	private final MetricsCounter metricsCounter = new MetricsCounter();
+	private final SkinApplierSponge skinApplierSponge = new SkinApplierSponge(this);
+	private final File dataFolder;
+	private final SRLogger srLogger;
+	private final MojangAPI mojangAPI;
+	private final SkinStorage skinStorage;
+	private final SkinsRestorerAPI skinsRestorerAPI;
+	private final MineSkinAPI mineSkinAPI;
+	@Inject
+	protected Game game;
+	private UpdateChecker updateChecker;
+	private SpongeCommandManager manager;
+	@Inject
+	private PluginContainer container;
 
-    @Inject
-    public SkinsRestorer(@SuppressWarnings("SpongeInjection") Metrics.Factory metricsFactory, @ConfigDir(sharedRoot = false) Path dataFolderPath, Logger log) {
-        metrics = metricsFactory.make(2337);
-        dataFolder = dataFolderPath.toFile();
-        srLogger = new SRLogger(new Slf4LoggerImpl(log));
-        mojangAPI = new MojangAPI(srLogger, Platform.SPONGE, metricsCounter);
-        mineSkinAPI = new MineSkinAPI(srLogger, mojangAPI, metricsCounter);
-        skinStorage = new SkinStorage(srLogger, mojangAPI, mineSkinAPI);
-        skinsRestorerAPI = new SkinsRestorerSpongeAPI(mojangAPI, skinStorage);
-    }
+	@Inject
+	public SkinsRestorer(@SuppressWarnings("SpongeInjection") Metrics.Factory metricsFactory, @ConfigDir(sharedRoot = false) Path dataFolderPath, Logger log) {
+		metrics = metricsFactory.make(2337);
+		dataFolder = dataFolderPath.toFile();
+		srLogger = new SRLogger(new Slf4LoggerImpl(log));
+		mojangAPI = new MojangAPI(srLogger, Platform.SPONGE, metricsCounter);
+		mineSkinAPI = new MineSkinAPI(srLogger, mojangAPI, metricsCounter);
+		skinStorage = new SkinStorage(srLogger, mojangAPI, mineSkinAPI);
+		skinsRestorerAPI = new SkinsRestorerSpongeAPI(mojangAPI, skinStorage);
+	}
 
-    @Listener
-    public void onInitialize(GameInitializationEvent e) {
-        srLogger.load(getDataFolder());
-        File updaterDisabled = new File(dataFolder, "noupdate.txt");
+	@Listener
+	public void onInitialize(GameInitializationEvent e) {
+		srLogger.load(getDataFolder());
+		File updaterDisabled = new File(dataFolder, "noupdate.txt");
 
-        // Check for updates
-        if (!updaterDisabled.exists()) {
-            updateChecker = new UpdateCheckerGitHub(2124, getVersion(), srLogger, "SkinsRestorerUpdater/Sponge");
-            checkUpdate();
+		// Check for updates
+		if (!updaterDisabled.exists()) {
+			updateChecker = new UpdateCheckerGitHub(2124, getVersion(), srLogger, "SkinsRestorerUpdater/Sponge");
+			checkUpdate();
 
-            Random rn = new Random();
-            int delayInt = 60 + rn.nextInt(240 - 60 + 1);
-            Sponge.getScheduler().createTaskBuilder().execute(() ->
-                    checkUpdate(false)).interval(delayInt, TimeUnit.MINUTES).delay(delayInt, TimeUnit.MINUTES);
-        } else {
-            srLogger.info("Updater Disabled");
-        }
+			Random rn = new Random();
+			int delayInt = 60 + rn.nextInt(240 - 60 + 1);
+			Sponge.getScheduler().createTaskBuilder().execute(() ->
+					checkUpdate(false)).interval(delayInt, TimeUnit.MINUTES).delay(delayInt, TimeUnit.MINUTES);
+		} else {
+			srLogger.info("Updater Disabled");
+		}
 
-        // Init config files
-        Config.load(dataFolder, getResource("config.yml"), srLogger);
-        Locale.load(dataFolder, srLogger);
+		// Init config files
+		Config.load(dataFolder, getResource("config.yml"), srLogger);
+		Locale.load(dataFolder, srLogger);
 
-        // Init storage
-        if (!initStorage())
-            return;
+		// Init storage
+		if (!initStorage())
+			return;
 
-        // Init commands
-        initCommands();
+		// Init commands
+		initCommands();
 
-        // Run connection check
-        Sponge.getScheduler().createAsyncExecutor(this).execute(() -> SharedMethods.runServiceCheck(mojangAPI, srLogger));
-    }
+		// Run connection check
+		Sponge.getScheduler().createAsyncExecutor(this).execute(() -> SharedMethods.runServiceCheck(mojangAPI, srLogger));
+	}
 
-    @Listener
-    public void onServerStarted(GameStartedServerEvent event) {
-        if (!Sponge.getServer().getOnlineMode()) {
-            Sponge.getEventManager().registerListener(this, ClientConnectionEvent.Auth.class, new LoginListener(this, srLogger));
-        }
+	@Listener
+	public void onServerStarted(GameStartedServerEvent event) {
+		Sponge.getEventManager().registerListener(this, ClientConnectionEvent.Auth.class, new LoginListener(this));
 
-        metrics.addCustomChart(new SingleLineChart("mineskin_calls", metricsCounter::collectMineskinCalls));
-        metrics.addCustomChart(new SingleLineChart("minetools_calls", metricsCounter::collectMinetoolsCalls));
-        metrics.addCustomChart(new SingleLineChart("mojang_calls", metricsCounter::collectMojangCalls));
-        metrics.addCustomChart(new SingleLineChart("ashcon_calls", metricsCounter::collectAshconCalls));
-    }
+		metrics.addCustomChart(new SingleLineChart("mineskin_calls", metricsCounter::collectMineskinCalls));
+		metrics.addCustomChart(new SingleLineChart("minetools_calls", metricsCounter::collectMinetoolsCalls));
+		metrics.addCustomChart(new SingleLineChart("mojang_calls", metricsCounter::collectMojangCalls));
+		metrics.addCustomChart(new SingleLineChart("ashcon_calls", metricsCounter::collectAshconCalls));
+	}
 
-    private void initCommands() {
-        Sponge.getPluginManager().getPlugin("skinsrestorer").ifPresent(pluginContainer -> {
-            manager = new SpongeCommandManager(pluginContainer);
+	private void initCommands() {
+		Sponge.getPluginManager().getPlugin("skinsrestorer").ifPresent(pluginContainer -> {
+			manager = new SpongeCommandManager(pluginContainer);
 
-            prepareACF(manager, srLogger);
+			prepareACF(manager, srLogger);
 
-            manager.registerCommand(new SkinCommand(this));
-            manager.registerCommand(new SrCommand(this));
-        });
-    }
+			manager.registerCommand(new SkinCommand(this));
+			manager.registerCommand(new SrCommand(this));
+		});
+	}
 
-    private boolean initStorage() {
-        // Initialise MySQL
-        if (!SharedMethods.initMysql(srLogger, skinStorage, dataFolder)) return false;
+	private boolean initStorage() {
+		// Initialise MySQL
+		if (!SharedMethods.initMysql(srLogger, skinStorage, dataFolder)) return false;
 
-        // Preload default skins
-        Sponge.getScheduler().createAsyncExecutor(this).execute(skinStorage::preloadDefaultSkins);
-        return true;
-    }
+		// Preload default skins
+		Sponge.getScheduler().createAsyncExecutor(this).execute(skinStorage::preloadDefaultSkins);
+		return true;
+	}
 
-    private void checkUpdate() {
-        checkUpdate(true);
-    }
+	private void checkUpdate() {
+		checkUpdate(true);
+	}
 
-    private void checkUpdate(boolean showUpToDate) {
-        Sponge.getScheduler().createAsyncExecutor(this).execute(() -> updateChecker.checkForUpdate(new UpdateCallback() {
-            @Override
-            public void updateAvailable(String newVersion, String downloadUrl, boolean hasDirectDownload) {
-                updateChecker.getUpdateAvailableMessages(newVersion, downloadUrl, hasDirectDownload, getVersion(), SkinsRestorer.BUNGEE_ENABLED).forEach(srLogger::info);
-            }
+	private void checkUpdate(boolean showUpToDate) {
+		Sponge.getScheduler().createAsyncExecutor(this).execute(() -> updateChecker.checkForUpdate(new UpdateCallback() {
+			@Override
+			public void updateAvailable(String newVersion, String downloadUrl, boolean hasDirectDownload) {
+				updateChecker.getUpdateAvailableMessages(newVersion, downloadUrl, hasDirectDownload, getVersion(), SkinsRestorer.BUNGEE_ENABLED).forEach(srLogger::info);
+			}
 
-            @Override
-            public void upToDate() {
-                if (!showUpToDate)
-                    return;
+			@Override
+			public void upToDate() {
+				if (!showUpToDate)
+					return;
 
-                updateChecker.getUpToDateMessages(getVersion(), SkinsRestorer.BUNGEE_ENABLED).forEach(srLogger::info);
-            }
-        }));
-    }
+				updateChecker.getUpToDateMessages(getVersion(), SkinsRestorer.BUNGEE_ENABLED).forEach(srLogger::info);
+			}
+		}));
+	}
 
-    @Override
-    public String getVersion() {
-        return container.getVersion().orElse("Unknown");
-    }
+	@Override
+	public String getVersion() {
+		return container.getVersion().orElse("Unknown");
+	}
 
-    @Override
-    public InputStream getResource(String resource) {
-        return getClass().getClassLoader().getResourceAsStream(resource);
-    }
+	@Override
+	public InputStream getResource(String resource) {
+		return getClass().getClassLoader().getResourceAsStream(resource);
+	}
 
-    @Override
-    public void runAsync(Runnable runnable) {
-        game.getScheduler().createAsyncExecutor(this).execute(runnable);
-    }
+	@Override
+	public void runAsync(Runnable runnable) {
+		game.getScheduler().createAsyncExecutor(this).execute(runnable);
+	}
 
-    @Override
-    public Collection<ISRPlayer> getOnlinePlayers() {
-        return game.getServer().getOnlinePlayers().stream().map(WrapperSponge::wrapPlayer).collect(Collectors.toList());
-    }
+	@Override
+	public Collection<ISRPlayer> getOnlinePlayers() {
+		return game.getServer().getOnlinePlayers().stream().map(WrapperSponge::wrapPlayer).collect(Collectors.toList());
+	}
 
-    private static class WrapperFactorySponge extends WrapperFactory {
-        @Override
-        public ISRPlayer wrapPlayer(Object playerInstance) {
-            if (playerInstance instanceof Player) {
-                Player player = (Player) playerInstance;
+	private static class WrapperFactorySponge extends WrapperFactory {
+		@Override
+		public ISRPlayer wrapPlayer(Object playerInstance) {
+			if (playerInstance instanceof Player) {
+				Player player = (Player) playerInstance;
 
-                return WrapperSponge.wrapPlayer(player);
-            } else {
-                throw new IllegalArgumentException("Player instance is not valid!");
-            }
-        }
-    }
+				return WrapperSponge.wrapPlayer(player);
+			} else {
+				throw new IllegalArgumentException("Player instance is not valid!");
+			}
+		}
+	}
 
-    private class SkinsRestorerSpongeAPI extends SkinsRestorerAPI {
-        public SkinsRestorerSpongeAPI(MojangAPI mojangAPI, SkinStorage skinStorage) {
-            super(mojangAPI, mineSkinAPI, skinStorage, new WrapperFactorySponge());
-        }
+	private class SkinsRestorerSpongeAPI extends SkinsRestorerAPI {
+		public SkinsRestorerSpongeAPI(MojangAPI mojangAPI, SkinStorage skinStorage) {
+			super(mojangAPI, mineSkinAPI, skinStorage, new WrapperFactorySponge());
+		}
 
-        @Override
-        public void applySkin(PlayerWrapper playerWrapper) throws SkinRequestException {
-            applySkin(playerWrapper, playerWrapper.get(Player.class).getName());
-        }
+		@Override
+		public void applySkin(PlayerWrapper playerWrapper) throws SkinRequestException {
+			applySkin(playerWrapper, playerWrapper.get(Player.class).getName());
+		}
 
-        @Override
-        public void applySkin(PlayerWrapper playerWrapper, String name) throws SkinRequestException {
-            applySkin(playerWrapper, skinStorage.getSkinForPlayer(name));
-        }
+		@Override
+		public void applySkin(PlayerWrapper playerWrapper, String name) throws SkinRequestException {
+			applySkin(playerWrapper, skinStorage.getSkinForPlayer(name));
+		}
 
-        @Override
-        public void applySkin(PlayerWrapper playerWrapper, IProperty props) {
-            skinApplierSponge.applySkin(playerWrapper.get(Player.class), props);
-        }
-    }
+		@Override
+		public void applySkin(PlayerWrapper playerWrapper, IProperty props) {
+			skinApplierSponge.applySkin(playerWrapper.get(Player.class), props);
+		}
+	}
 }

--- a/velocity/src/main/java/net/skinsrestorer/velocity/SkinsRestorer.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/SkinsRestorer.java
@@ -130,7 +130,7 @@ public class SkinsRestorer implements ISRPlugin {
             return;
 
         // Init listener
-        proxy.getEventManager().register(this, new GameProfileRequest(this, srLogger));
+        proxy.getEventManager().register(this, new GameProfileRequest(this));
 
         // Init commands
         initCommands();


### PR DESCRIPTION
Issue:
Player changing skin in launcher and joining will not be same as what mojang api is saying (30m - 1hour delay)

Solution:
Do not apply the skin if:
- server is online mode
- player has NO skin set
- Config.ALWAYS_APPLY_PREMIUM = false
- onjoin event does contain skin property (player has premium skin) 

This way, the premium user will join the premium server with the launcher provided skin (if no skin is set / defaultskins.premium)

Todo:
- [ ] Same for sponge and velocity
- [ ] Strip pname of invalid mojang name


.
- [ ] test default skin & applypremium