### PR TITLE
Rename multibungee to forward textures and enable by default

### DIFF
--- a/bukkit/src/main/java/net/skinsrestorer/bukkit/utils/MappingManager.java
+++ b/bukkit/src/main/java/net/skinsrestorer/bukkit/utils/MappingManager.java
@@ -48,7 +48,7 @@ public class MappingManager {
         return Optional.empty();
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"deprecation"})
     public static String getMappingsVersion() {
         UnsafeValues craftMagicNumbers = Bukkit.getServer().getUnsafe();
         try {

--- a/bungee/src/main/java/net/skinsrestorer/bungee/SkinApplierBungee.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/SkinApplierBungee.java
@@ -29,6 +29,7 @@ import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.api.reflection.ReflectionUtil;
 import net.skinsrestorer.api.reflection.exception.ReflectionException;
+import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.utils.log.SRLogger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -44,7 +45,7 @@ public class SkinApplierBungee {
 
     public void applySkin(String nick, InitialHandler handler) throws SkinRequestException {
         try {
-            applySkin(null, plugin.getSkinStorage().getSkinForPlayer(nick), handler);
+            applyEvent(null, plugin.getSkinStorage().getSkinForPlayer(nick), handler);
         } catch (ReflectionException e) {
             e.printStackTrace();
         }
@@ -52,18 +53,13 @@ public class SkinApplierBungee {
 
     protected void applySkin(ProxiedPlayer player, IProperty property) {
         try {
-            applySkin(player, property, (InitialHandler) player.getPendingConnection());
+            applyEvent(player, property, (InitialHandler) player.getPendingConnection());
         } catch (ReflectionException e) {
             e.printStackTrace();
         }
     }
 
-    private void applySkin(@Nullable ProxiedPlayer player, IProperty property, InitialHandler handler) throws ReflectionException {
-        if (handler == null) {
-            assert player != null;
-            handler = (InitialHandler) player.getPendingConnection();
-        }
-
+    private void applyEvent(@Nullable ProxiedPlayer player, IProperty property, InitialHandler handler) throws ReflectionException {
         SkinApplyBungeeEvent event = new SkinApplyBungeeEvent(player, property);
 
         plugin.getProxy().getPluginManager().callEvent(event);
@@ -79,11 +75,7 @@ public class SkinApplierBungee {
         if (player == null)
             return;
 
-        if (plugin.isMultiBungee()) {
-            sendUpdateRequest(player, textures);
-        } else {
-            sendUpdateRequest(player, null);
-        }
+        sendUpdateRequest(player, Config.FORWARD_TEXTURES ? textures : null);
     }
 
     private void applyToHandler(InitialHandler handler, Property textures) throws ReflectionException {

--- a/bungee/src/main/java/net/skinsrestorer/bungee/SkinsRestorer.java
+++ b/bungee/src/main/java/net/skinsrestorer/bungee/SkinsRestorer.java
@@ -74,7 +74,6 @@ public class SkinsRestorer extends Plugin implements ISRPlugin {
     private final SkinStorage skinStorage = new SkinStorage(srLogger, mojangAPI, mineSkinAPI);
     private final SkinsRestorerAPI skinsRestorerAPI = new SkinsRestorerBungeeAPI(mojangAPI, skinStorage);
     private final SkinApplierBungee skinApplierBungee = new SkinApplierBungee(this, srLogger);
-    private boolean multiBungee;
     private boolean outdated;
     private UpdateChecker updateChecker;
     private PluginMessageListener pluginMessageListener;
@@ -129,8 +128,6 @@ public class SkinsRestorer extends Plugin implements ISRPlugin {
         getProxy().registerChannel("sr:messagechannel");
         pluginMessageListener = new PluginMessageListener(this);
         getProxy().getPluginManager().registerListener(this, pluginMessageListener);
-
-        multiBungee = Config.MULTI_BUNGEE_ENABLED || ProxyServer.getInstance().getPluginManager().getPlugin("RedisBungee") != null;
 
         // Run connection check
         getProxy().getScheduler().runAsync(this, () -> SharedMethods.runServiceCheck(mojangAPI, srLogger));

--- a/shared/src/main/java/net/skinsrestorer/shared/storage/Config.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/storage/Config.java
@@ -42,7 +42,7 @@ public class Config {
     public static List<String> CUSTOM_GUI_SKINS = null;
     public static boolean PER_SKIN_PERMISSIONS = false;
     public static int SKIN_EXPIRES_AFTER = 20;
-    public static boolean FORWARD_TEXTURES = false;
+    public static boolean FORWARD_TEXTURES = true;
     public static boolean MYSQL_ENABLED = false;
     public static String MYSQL_HOST = "localhost";
     public static String MYSQL_PORT = "3306";

--- a/shared/src/main/java/net/skinsrestorer/shared/storage/Config.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/storage/Config.java
@@ -42,7 +42,7 @@ public class Config {
     public static List<String> CUSTOM_GUI_SKINS = null;
     public static boolean PER_SKIN_PERMISSIONS = false;
     public static int SKIN_EXPIRES_AFTER = 20;
-    public static boolean MULTI_BUNGEE_ENABLED = false;
+    public static boolean FORWARD_TEXTURES = false;
     public static boolean MYSQL_ENABLED = false;
     public static String MYSQL_HOST = "localhost";
     public static String MYSQL_PORT = "3306";
@@ -91,7 +91,7 @@ public class Config {
         CUSTOM_GUI_SKINS = config.getStringList("CustomGUI.Names");
         PER_SKIN_PERMISSIONS = config.getBoolean("PerSkinPermissions", PER_SKIN_PERMISSIONS);
         SKIN_EXPIRES_AFTER = config.getInt("SkinExpiresAfter", SKIN_EXPIRES_AFTER);
-        MULTI_BUNGEE_ENABLED = config.getBoolean("MultiBungee.Enabled", MULTI_BUNGEE_ENABLED);
+        FORWARD_TEXTURES = config.getBoolean("ForwardTextures", FORWARD_TEXTURES);
         MYSQL_ENABLED = config.getBoolean("MySQL.Enabled", MYSQL_ENABLED);
         MYSQL_HOST = config.getString("MySQL.Host", MYSQL_HOST);
         MYSQL_PORT = config.getString("MySQL.Port", MYSQL_PORT);

--- a/shared/src/main/resources/config.yml
+++ b/shared/src/main/resources/config.yml
@@ -90,13 +90,6 @@ PerSkinPermissions: false
 # Time that skins are stored in the database before we request again (in minutes).
 SkinExpiresAfter: 15
 
-# Multi-Bungee support
-# Enable this if you have issues with skins in multi-proxy environments.
-# (?) If you're using bungee and you have the plugin in all spigot servers and it still does not work, turn this on.
-# (This is automatically enabled if you have RedisBungee)
-MultiBungee:
-  Enabled: false
-
 # Settings for MySQL skin storage (recommended for big BungeeCord networks)
 # [!] IF YOU USE BUNGEE, DO NOT ENABLE MYSQL in the Spigot / backend config.yml [!]
 # [!] Non-root users: MySQL 8's new default authentication is not supported, use mysql_native_password [!]
@@ -174,12 +167,19 @@ DisallowAutoUpdateSkin: false
 # Use with caution! This may decrease your TPS.
 EnableProtocolListener: false
 
+# <!! Warning !!>
+# When enabled if a skin gets applied on the proxy, the new texture will be forwarded to the backend as well.
+# This is optional sometimes as the backend may pick up the new one of the proxy.
+# It is recommended though to **KEEP THIS ON** because it keeps the backend data in sync.
+# This feature is required for solutions like RedisBungee and also fixes bugs in some cases.
+ForwardTextures: true
+
 # Updater Settings
 Updater:
 # # <!! Warning !!>
 # Using outdated version void's support, compatibility & stability.
 #
-# To block all types of automatic updates (which can risk keeping a exploit):
+# To block all types of automatic updates (which can risk keeping an exploit):
 # Create a file called 'noupdate.txt' in the plugin directory (./plugins/SkinsRestorer/ )
 
 ################

--- a/velocity/src/main/java/net/skinsrestorer/velocity/SkinApplierVelocity.java
+++ b/velocity/src/main/java/net/skinsrestorer/velocity/SkinApplierVelocity.java
@@ -28,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 import net.skinsrestorer.api.exception.SkinRequestException;
 import net.skinsrestorer.api.property.IProperty;
 import net.skinsrestorer.api.velocity.events.SkinApplyVelocityEvent;
+import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.utils.log.SRLogger;
 
 import java.io.ByteArrayOutputStream;
@@ -46,7 +47,7 @@ public class SkinApplierVelocity {
             if (event.getResult() != ResultedEvent.GenericResult.allowed())
                 return;
             player.setGameProfileProperties(updatePropertiesSkin(player.getGameProfileProperties(), (Property) property.getHandle()));
-            sendUpdateRequest(player, (Property) property.getHandle());
+            sendUpdateRequest(player, Config.FORWARD_TEXTURES ? (Property) property.getHandle() : null);
         });
     }
 


### PR DESCRIPTION
Always forwarding skin textures keeps the backend data in sync with the proxy data and prevents any sort of interference.
Should fix the online mode issue on bungeecord as well. Was never an issue on velocity because we always sent the textures there already.