### PR TITLE
Enhance build speed by dropping paperweight

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     implementation("gradle.plugin.com.github.johnrengelman:shadow:7.1.2")
     implementation("gradle.plugin.org.cadixdev.gradle:licenser:0.6.1")
     implementation("net.kyori:indra-common:2.1.1")
-    implementation("io.papermc.paperweight.userdev:io.papermc.paperweight.userdev.gradle.plugin:1.3.5")
+    implementation("io.github.patrick.remapper:io.github.patrick.remapper.gradle.plugin:1.3.0")
 }
 
-java.targetCompatibility = JavaVersion.VERSION_1_8
+java.targetCompatibility = JavaVersion.VERSION_17

--- a/buildSrc/src/main/kotlin/extensions.kt
+++ b/buildSrc/src/main/kotlin/extensions.kt
@@ -1,4 +1,3 @@
-import io.papermc.paperweight.util.constants.DEV_BUNDLE_CONFIG
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ExternalModuleDependency
@@ -32,20 +31,3 @@ fun JavaPluginExtension.javaTarget(version: Int) {
     sourceCompatibility = JavaVersion.toVersion(version)
     targetCompatibility = JavaVersion.toVersion(version)
 }
-
-fun Project.setup(version: String) {
-    dependencies {
-        paperDevBundle(version)
-    }
-}
-
-fun DependencyHandlerScope.paperDevBundle(
-    version: String? = null,
-    group: String = "io.papermc.paper",
-    artifactId: String = "dev-bundle",
-    configuration: String? = null,
-    classifier: String? = null,
-    ext: String? = null,
-    devBundleConfigurationName: String = DEV_BUNDLE_CONFIG,
-    configurationAction: ExternalModuleDependency.() -> Unit = {}
-): ExternalModuleDependency = devBundleConfigurationName(group, artifactId, version, configuration, classifier, ext, configurationAction)

--- a/buildSrc/src/main/kotlin/sr.mapping-logic.gradle.kts
+++ b/buildSrc/src/main/kotlin/sr.mapping-logic.gradle.kts
@@ -13,13 +13,17 @@ java {
     }
 }
 
+tasks.remap.get().apply {
+    archiveClassifier.set("remapped")
+}
+
 tasks.named("remap").get().dependsOn("jar")
 tasks.named("build").get().dependsOn("remap")
 
 configurations {
-    create("reobfuscated") {
+    create("remapped") {
         isCanBeResolved = false
         isCanBeConsumed = true
-        outgoing.artifact(tasks.jar.get().archiveFile)
+        outgoing.artifact(File(File(project.buildDir, "libs"), "${project.name}-${project.version}-remapped.jar"))
     }
 }

--- a/buildSrc/src/main/kotlin/sr.mapping-logic.gradle.kts
+++ b/buildSrc/src/main/kotlin/sr.mapping-logic.gradle.kts
@@ -2,9 +2,23 @@ plugins {
     java
     id("sr.license-logic")
     id("sr.core-dependencies")
-    id("io.papermc.paperweight.userdev")
+    id("io.github.patrick.remapper")
 }
 
 dependencies.implementation(project(":mappings:shared"))
 
-tasks.named("build").get().dependsOn("reobfJar")
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+tasks.named("remap").get().dependsOn("jar")
+
+configurations {
+    create("reobfuscated") {
+        isCanBeResolved = false
+        isCanBeConsumed = true
+        outgoing.artifact(tasks.jar.get().archiveFile)
+    }
+}

--- a/buildSrc/src/main/kotlin/sr.mapping-logic.gradle.kts
+++ b/buildSrc/src/main/kotlin/sr.mapping-logic.gradle.kts
@@ -14,6 +14,7 @@ java {
 }
 
 tasks.named("remap").get().dependsOn("jar")
+tasks.named("build").get().dependsOn("remap")
 
 configurations {
     create("reobfuscated") {

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -3,7 +3,7 @@ dependencies {
     implementation(projects.skinsrestorerShared)
     implementation(projects.mappings.shared)
     setOf("1-18", "1-18-2").forEach {
-        implementation(project(":mappings:mc-$it", "reobfuscated"))
+        implementation(project(":mappings:mc-$it", "remapped"))
     }
 
     compileOnly("org.spigotmc:spigot-api:1.18.2-R0.1-SNAPSHOT") {

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -2,8 +2,9 @@ dependencies {
     implementation(projects.skinsrestorerApi)
     implementation(projects.skinsrestorerShared)
     implementation(projects.mappings.shared)
-    implementation(projects.mappings.mc118)
-    implementation(projects.mappings.mc1182)
+    setOf("1-18", "1-18-2").forEach {
+        implementation(project(":mappings:mc-$it", "reobfuscated"))
+    }
 
     compileOnly("org.spigotmc:spigot-api:1.18.2-R0.1-SNAPSHOT") {
         exclude("com.google.code.gson", "gson")

--- a/mappings/mc-1-18-2/build.gradle.kts
+++ b/mappings/mc-1-18-2/build.gradle.kts
@@ -1,1 +1,10 @@
-setup("1.18.2-R0.1-SNAPSHOT")
+tasks {
+    remap {
+        version.set("1.18.2")
+    }
+}
+
+dependencies.apply {
+    compileOnly("io.papermc.paper:paper-server:1.18.2-R0.1-SNAPSHOT:mojang-mapped@jar")
+    compileOnly("org.spigotmc:spigot:1.18.2-R0.1-SNAPSHOT")
+}

--- a/mappings/mc-1-18/build.gradle.kts
+++ b/mappings/mc-1-18/build.gradle.kts
@@ -1,1 +1,10 @@
-setup("1.18-R0.1-SNAPSHOT")
+tasks {
+    remap {
+        version.set("1.18")
+    }
+}
+
+dependencies.apply {
+    compileOnly("io.papermc.paper:paper-server:1.18.1-R0.1-SNAPSHOT:mojang-mapped@jar")
+    compileOnly("org.spigotmc:spigot:1.18-R0.1-SNAPSHOT")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@ pluginManagement {
         id("net.kyori.indra.git") version "2.1.1"
         id("net.kyori.indra.publishing") version "2.1.1"
         id("net.kyori.blossom") version "1.3.0"
-        id("io.papermc.paperweight.userdev") version "1.3.5"
+        id("io.github.patrick.remapper") version "1.3.0"
     }
 }
 


### PR DESCRIPTION
Each time we make a new build, the CI has to literally decompile minecraft, put paper patches inside the jar, fix the jar up, recompile it, patch again and decompile it again. Not sure if that is exactly what happens, but it's slow. And that for each version we support, so right now 1.18 and 1.18.2. With 1.19 around the corner, build speed is gonna go 📉. Not good. 
This PR introduces a new system that is based on the remap gradle plugin that uses specialsource behind the scenes. SpecialSource can take the mappings from repo.codemc.io, which paperweight userdev can't.
This way it simply downloads everything during build very quickly, compiles the mapping and then runs specialsource on it to obfuscate the code.