### PR TITLE
Remove the class name from error messages sent to players

### DIFF
--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISRCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISRCommand.java
@@ -32,6 +32,7 @@ import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.storage.Locale;
 import net.skinsrestorer.shared.utils.C;
 import net.skinsrestorer.shared.utils.connections.ServiceChecker;
+import static net.skinsrestorer.shared.utils.SharedMethods.getRootCause;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -193,7 +194,7 @@ public interface ISRCommand {
                     sender.sendMessage(Locale.ERROR_INVALID_URLSKIN);
                 }
             } catch (SkinRequestException e) {
-                sender.sendMessage(e.getMessage());
+                sender.sendMessage(getRootCause(e).getMessage());
             }
         });
     }
@@ -230,7 +231,7 @@ public interface ISRCommand {
                 }
                 sender.sendMessage("§aSuccessfully set skin of all online players to " + skin);
             } catch (SkinRequestException e) {
-                sender.sendMessage(e.getMessage());
+                sender.sendMessage(getRootCause(e).getMessage());
             }
         });
     }

--- a/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/commands/ISkinCommand.java
@@ -33,6 +33,7 @@ import net.skinsrestorer.shared.storage.Config;
 import net.skinsrestorer.shared.storage.Locale;
 import net.skinsrestorer.shared.utils.C;
 import net.skinsrestorer.shared.utils.log.SRLogLevel;
+import static net.skinsrestorer.shared.utils.SharedMethods.getRootCause;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -90,7 +91,7 @@ public interface ISkinCommand {
             } catch (NotPremiumException e) {
                 SkinsRestorerAPI.getApi().applySkin(target.getWrapper(), emptySkin);
             } catch (SkinRequestException e) {
-                sender.sendMessage(e.getMessage());
+                sender.sendMessage(getRootCause(e).getMessage());
             }
 
             if (sender == target) {
@@ -145,7 +146,7 @@ public interface ISkinCommand {
                     skin = Optional.of(plugin.getSkinStorage().getDefaultSkinName(playerName, true).getLeft());
                 }
             } catch (SkinRequestException e) {
-                sender.sendMessage(e.getMessage());
+                sender.sendMessage(getRootCause(e).getMessage());
                 return;
             }
 
@@ -263,7 +264,7 @@ public interface ISkinCommand {
 
                 return true;
             } catch (SkinRequestException e) {
-                sender.sendMessage(e.getMessage());
+                sender.sendMessage(getRootCause(e).getMessage());
             } catch (Exception e) {
                 plugin.getSrLogger().debug(SRLogLevel.SEVERE, "Could not generate skin url: " + skin, e);
                 sender.sendMessage(Locale.ERROR_INVALID_URLSKIN);
@@ -284,7 +285,7 @@ public interface ISkinCommand {
 
                 return true;
             } catch (SkinRequestException e) {
-                sender.sendMessage(e.getMessage());
+                sender.sendMessage(getRootCause(e).getMessage());
             }
         }
 

--- a/shared/src/main/java/net/skinsrestorer/shared/utils/SharedMethods.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/utils/SharedMethods.java
@@ -89,4 +89,11 @@ public class SharedMethods {
 
         return true;
     }
+
+    public static Throwable getRootCause(Throwable throwable) {
+        if (throwable.getCause() != null)
+            return getRootCause(throwable.getCause());
+
+        return throwable;
+    }
 }


### PR DESCRIPTION
Fixes the issue with displaying exception's class name in error messages sent to players