### PR TITLE
Fix connection to the database using a password with special characters

### DIFF
--- a/shared/src/main/java/net/skinsrestorer/shared/storage/MySQL.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/storage/MySQL.java
@@ -100,15 +100,14 @@ public class MySQL {
     }
 
     public void connectPool() throws SQLException {
-        poolDataSource = new MariaDbPoolDataSource(
-                "jdbc:mysql://" + host + ":" + port + "/" + database +
-                        "?user=" + username +
-                        "&password=" + password +
-                        "&permitMysqlScheme" +
-                        "&maxPoolSize=" + maxPoolSize +
-                        "&" + options);
-
-        logger.info("Connected to MySQL!");
+        poolDataSource = new MariaDbPoolDataSource();
+        poolDataSource.setUser(username);
+        poolDataSource.setPassword(password);
+        poolDataSource.setUrl("jdbc:mysql://" + host + ":" + port + "/" + database +
+                "?permitMysqlScheme" +
+                "&maxPoolSize=" + maxPoolSize +
+                "&" + options
+        );
     }
 
     public void execute(@Language("sql") final String query, final Object... vars) {

--- a/shared/src/main/java/net/skinsrestorer/shared/utils/SharedMethods.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/utils/SharedMethods.java
@@ -81,6 +81,7 @@ public class SharedMethods {
                 mysql.connectPool();
                 mysql.createTable();
 
+                srLogger.info("Connected to MySQL!");
                 skinStorage.setStorageAdapter(new MySQLAdapter(mysql));
             } else {
                 skinStorage.setStorageAdapter(new FileAdapter(dataFolder));


### PR DESCRIPTION
Since some messages in proxy mode are taken from local files (for example, messages for GUI), it is necessary on the backend to load the configuration to set the selected localization as default. Otherwise, there will be a mismatch in the localization of messages between the server part and the proxy server

Also this PR fixes #1088 #1092 