### PR TITLE
Typo - "MineSkin API key is not invalid! ..."

### DIFF
--- a/shared/src/main/java/net/skinsrestorer/shared/connections/MineSkinAPIImpl.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/connections/MineSkinAPIImpl.java
@@ -125,7 +125,7 @@ public class MineSkinAPIImpl implements MineSkinAPI {
                 String errorCode = response.getErrorCode();
                 String error = response.getError();
                 if (errorCode.equals("invalid_api_key")) {
-                    logger.severe("[ERROR] MineSkin API key is not invalid! Reason: " + error);
+                    logger.severe("[ERROR] MineSkin API key is invalid! Reason: " + error);
                     switch (error) {
                         case "Invalid API Key" ->
                                 logger.severe(String.format("The API Key provided is not registered on MineSkin! Please empty \"%s\" in plugins/SkinsRestorer/config.yml and run /sr reload", APIConfig.MINESKIN_API_KEY.getPath()));


### PR DESCRIPTION
I noticed a small typo if the MineSkin API key is invalid and someone tries to set a skin from a URL.

```
[20:58:58 ERROR]: [SkinsRestorer] [ERROR] MineSkin API key is not invalid! Reason: Invalid API Key
```

Since it's hard-coded, I had to fix it in the source code.