### PR TITLE
Fix MineSkin API key

### DIFF
--- a/shared/src/main/java/net/skinsrestorer/shared/connections/MineSkinAPIImpl.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/connections/MineSkinAPIImpl.java
@@ -177,7 +177,7 @@ public class MineSkinAPIImpl implements MineSkinAPI {
                 Map<String, String> headers = new HashMap<>();
                 Optional<String> apiKey = getApiKey(settings);
                 if (apiKey.isPresent()) {
-                    headers.put("Authorization", "Bearer %s".formatted(apiKey));
+                    headers.put("Authorization", "Bearer %s".formatted(apiKey.get()));
                 }
 
                 return httpClient.execute(

--- a/shared/src/main/java/net/skinsrestorer/shared/connections/MineSkinAPIImpl.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/connections/MineSkinAPIImpl.java
@@ -176,9 +176,7 @@ public class MineSkinAPIImpl implements MineSkinAPI {
 
                 Map<String, String> headers = new HashMap<>();
                 Optional<String> apiKey = getApiKey(settings);
-                if (apiKey.isPresent()) {
-                    headers.put("Authorization", "Bearer %s".formatted(apiKey.get()));
-                }
+                apiKey.ifPresent(s -> headers.put("Authorization", "Bearer %s".formatted(s)));
 
                 return httpClient.execute(
                         MINESKIN_ENDPOINT,


### PR DESCRIPTION
I kept getting messages about MineSkin API keys not working in SkinsRestorer.  
Turns out this was using the optional instead of the actual value, resulting in sent API keys like `Optional[9bb4e8cd183...8682b53]`