### PR TITLE
Comment out MineSkinUrlResponse#account

### DIFF
--- a/shared/src/main/java/net/skinsrestorer/shared/connections/responses/mineskin/MineSkinUrlResponse.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/connections/responses/mineskin/MineSkinUrlResponse.java
@@ -33,7 +33,9 @@ public class MineSkinUrlResponse {
     private MineSkinData data;
     private long timestamp;
     private int duration;
-    private int account;
+    // sometimes account is returned as a string and sometimes as an int,
+    // so it's just easier to comment this field out, it's not used anyway
+    // private int account;
     private String server;
     @SerializedName("private")
     private boolean private_;


### PR DESCRIPTION
When API key is specified, "account" is returned as a string (https://github.com/MineSkin/mineskin-types/blob/163558152b9393a59c0218b933949cf292da5b96/src/skin/SkinInfo.ts#L20) and deserialization throws a NumberFormatException (#1869).

This field seems to be unused, so commenting it out fixes the issue.