### PR TITLE
Freeze Ubuntu version, Fix Gradle setup

### DIFF
--- a/.github/workflows/attach-hash.yml
+++ b/.github/workflows/attach-hash.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: robinraju/release-downloader@v1.12
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,20 +10,18 @@ jobs:
     # Only run on PRs if the source branch is on someone else's repo
     if: "${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}"
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle
         run: ./gradlew build test --stacktrace --scan
       - name: Generate and submit dependency graph

--- a/.github/workflows/deploy-javadoc.yml
+++ b/.github/workflows/deploy-javadoc.yml
@@ -4,7 +4,7 @@ on: [ workflow_dispatch, workflow_call ]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
 
@@ -13,15 +13,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
-      - name: Validate Gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: '21'
           distribution: 'temurin'
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle
         run: ./gradlew :skinsrestorer-api:javadoc --stacktrace
       - name: Move files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
   build:
     needs: set-release-version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:
@@ -27,15 +27,13 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ github.ref }}
-    - name: Validate Gradle wrapper
-      uses: gradle/actions/wrapper-validation@v4
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@v4
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         java-version: '21'
         distribution: 'temurin'
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
     - name: Build with Gradle
       run: ./gradlew build test --stacktrace --scan
 

--- a/.github/workflows/set-version.yml
+++ b/.github/workflows/set-version.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: write
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: 'Shared: Checkout repository'
         uses: actions/checkout@v4


### PR DESCRIPTION
The setup-gradle job already validates the wrapper JAR for us, as for the Ubuntu version; it should be frozen in case of possible CLI build failures from OS.