### PR TITLE
feat: Rename noupdate.txt to noautoupdate.txt

### DIFF
--- a/shared/src/main/java/net/skinsrestorer/shared/config/DevConfig.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/config/DevConfig.java
@@ -37,7 +37,7 @@ public class DevConfig implements SettingsHolder {
                 "Using outdated version void's support, compatibility & stability.",
                 "\n",
                 "To block all types of automatic updates (which can risk keeping an exploit):",
-                "Create a file called 'noupdate.txt' in the plugin directory (./plugins/SkinsRestorer/ )",
+                "Create a file called 'noautoupdate.txt' in the plugin directory (./plugins/SkinsRestorer/ )",
                 "\n",
                 "\n################",
                 "\n# DEV's corner #",

--- a/shared/src/main/java/net/skinsrestorer/shared/update/UpdateCheckInit.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/update/UpdateCheckInit.java
@@ -39,7 +39,8 @@ public class UpdateCheckInit {
     private final Injector injector;
 
     public Optional<UpdateDownloader> getDownloader() {
-        boolean downloaderDisabled = Files.exists(plugin.getDataFolder().resolve("noupdate.txt"));
+        boolean downloaderDisabled = Files.exists(plugin.getDataFolder().resolve("noautoupdate.txt"))
+                || Files.exists(plugin.getDataFolder().resolve("noupdate.txt")); // Legacy support
         if (downloaderDisabled) {
             logger.info("Auto updater was manually disabled. This is not recommended, as it will prevent the plugin from updating automatically. See why at: https://skinsrestorer.net/docs/configuration/auto-update");
         }

--- a/shared/src/main/java/net/skinsrestorer/shared/update/UpdateCheckerGitHub.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/update/UpdateCheckerGitHub.java
@@ -117,8 +117,9 @@ public class UpdateCheckerGitHub {
         logger.info("§b    Commit: §a%s".formatted(BuildData.COMMIT_SHORT));
         if (cause == UpdateCause.NETWORK_DISABLED) {
             logger.info("§c    Network connections are disabled in the SkinsRestorer config (advanced.noConnections), we will not check for updates.");
-        } else if (Files.exists(plugin.getDataFolder().resolve("noupdate.txt"))) {
-            logger.info("§e    The updater is disabled using noupdate.txt");
+        } else if (Files.exists(plugin.getDataFolder().resolve("noautoupdate.txt"))
+                || Files.exists(plugin.getDataFolder().resolve("noupdate.txt"))) { // Legacy support
+            logger.info("§e    The updater is disabled using noautoupdate.txt");
         } else {
             logger.info("§a    This is the latest version!");
         }


### PR DESCRIPTION
Renamed the auto-updater disable file from noupdate.txt to noautoupdate.txt for better clarity. Legacy support for noupdate.txt is maintained for backward compatibility.