### PR TITLE
Fix: use ASCII charset for URL columns to prevent InnoDB key size overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ target/
 .project
 .factorypath
 
+# OS files
+.DS_Store
+
 # UML
 *.plantuml
 

--- a/shared/src/main/java/net/skinsrestorer/shared/storage/adapter/mysql/MySQLAdapter.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/storage/adapter/mysql/MySQLAdapter.java
@@ -105,7 +105,7 @@ public class MySQLAdapter implements StorageAdapter {
                 + "PRIMARY KEY (`uuid`)) ENGINE=InnoDB DEFAULT CHARSET=utf8");
 
         mysql.update("CREATE TABLE IF NOT EXISTS `" + resolveURLSkinTable() + "` ("
-                + "`url` VARCHAR(266) NOT NULL," // Max chatbox command length
+                + "`url` VARCHAR(266) CHARACTER SET ascii NOT NULL," // Max chatbox command length, ASCII keeps key under 767 bytes
                 + "`mine_skin_id` VARCHAR(36),"
                 + "`value` TEXT NOT NULL,"
                 + "`signature` TEXT NOT NULL,"
@@ -113,7 +113,7 @@ public class MySQLAdapter implements StorageAdapter {
                 + "PRIMARY KEY (`url`, `skin_variant`)) ENGINE=InnoDB DEFAULT CHARSET=utf8");
 
         mysql.update("CREATE TABLE IF NOT EXISTS `" + resolveURLSkinIndexTable() + "` ("
-                + "`url` VARCHAR(266) NOT NULL," // Max chatbox command length
+                + "`url` VARCHAR(266) CHARACTER SET ascii NOT NULL," // Max chatbox command length, ASCII keeps key under 767 bytes
                 + "`skin_variant` VARCHAR(20),"
                 + "PRIMARY KEY (`url`)) ENGINE=InnoDB DEFAULT CHARSET=utf8");
 


### PR DESCRIPTION
Multiple users (including several people I know personally) have been
hitting a confusing "table doesn't exist" error at runtime when using
free/shared MySQL hosting or servers with default configurations.

The root cause: the url column in url_skins and url_index tables
used utf8 charset (3 bytes per character), making the primary key larger
than the InnoDB 767-byte limit. This limit applies to MySQL < 5.7.7,
MariaDB < 10.2.2, and any setup where innodb_large_prefix is not
enabled - such as free/shared hosting, managed cloud databases with
default settings, and Docker or CI/CD environments with default configs.

CREATE TABLE failed silently (error is swallowed by
MySQLProvider.update()), so users got no indication that table creation
failed during startup.

URLs can only contain ASCII characters (RFC 3986), so CHARACTER SET ascii
(1 byte per character) is the correct choice here and keeps the key size
well under the limit on all MySQL/MariaDB versions and environments.

Also added .DS_Store to .gitignore.

<3