### PR TITLE
Add player:/custom: prefix syntax to disambiguate skin lookups

### DIFF
--- a/shared/src/main/java/net/skinsrestorer/shared/storage/SkinInput.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/storage/SkinInput.java
@@ -1,0 +1,54 @@
+/*
+ * SkinsRestorer
+ * Copyright (C) 2024  SkinsRestorer Team
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package net.skinsrestorer.shared.storage;
+
+import net.skinsrestorer.api.property.SkinType;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents a parsed skin input string that may include an explicit type prefix.
+ * <p>
+ * Supported prefixes:
+ * <ul>
+ *     <li>{@code player:<name>} — force player skin lookup</li>
+ *     <li>{@code custom:<name>} — force custom skin lookup</li>
+ *     <li>{@code <name>} (no prefix) — default behavior (custom first, then player)</li>
+ * </ul>
+ *
+ * @param name     The skin name with the prefix stripped.
+ * @param typeHint The explicit skin type, or null for default lookup order.
+ */
+public record SkinInput(String name, @Nullable SkinType typeHint) {
+    private static final String PLAYER_PREFIX = "player:";
+    private static final String CUSTOM_PREFIX = "custom:";
+
+    /**
+     * Parses a raw skin input string, extracting an optional type prefix.
+     *
+     * @param input The raw input (e.g. "S0yoneyro", "player:S0yoneyro", "custom:myskin").
+     * @return A SkinInput with the prefix stripped and the type hint set.
+     */
+    public static SkinInput parse(String input) {
+        if (input.startsWith(PLAYER_PREFIX)) {
+            return new SkinInput(input.substring(PLAYER_PREFIX.length()), SkinType.PLAYER);
+        } else if (input.startsWith(CUSTOM_PREFIX)) {
+            return new SkinInput(input.substring(CUSTOM_PREFIX.length()), SkinType.CUSTOM);
+        }
+        return new SkinInput(input, null);
+    }
+}

--- a/shared/src/main/java/net/skinsrestorer/shared/storage/SkinStorageImpl.java
+++ b/shared/src/main/java/net/skinsrestorer/shared/storage/SkinStorageImpl.java
@@ -219,6 +219,9 @@ public class SkinStorageImpl implements SkinStorage {
     @Override
     public Optional<InputDataResult> findSkinData(String input, SkinVariant skinVariantHint) {
         input = SRHelpers.sanitizeSkinInput(input);
+        SkinInput skinInput = SkinInput.parse(input);
+        input = skinInput.name();
+        SkinType typeHint = skinInput.typeHint();
 
         try {
             if (ValidationUtil.validSkinUrl(input)) {
@@ -244,24 +247,26 @@ public class SkinStorageImpl implements SkinStorage {
                     return result;
                 }
 
-                Optional<CustomSkinData> customSkinData = adapterReference.get().getCustomSkinData(input);
+                if (typeHint != SkinType.PLAYER) {
+                    Optional<CustomSkinData> customSkinData = adapterReference.get().getCustomSkinData(input);
 
-                if (customSkinData.isPresent()) {
-                    return customSkinData.map(data ->
-                            InputDataResult.of(SkinIdentifier.ofCustom(data.getSkinName()), data.getProperty()));
+                    if (customSkinData.isPresent()) {
+                        return customSkinData.map(data ->
+                                InputDataResult.of(SkinIdentifier.ofCustom(data.getSkinName()), data.getProperty()));
+                    }
                 }
 
-                Optional<UUID> uuid = cacheStorage.getUUID(input, false);
+                if (typeHint != SkinType.CUSTOM) {
+                    Optional<UUID> uuid = cacheStorage.getUUID(input, false);
 
-                if (uuid.isEmpty()) {
-                    return Optional.empty();
-                }
+                    if (uuid.isPresent()) {
+                        Optional<PlayerSkinData> playerSkinData = adapterReference.get().getPlayerSkinData(uuid.get());
 
-                Optional<PlayerSkinData> playerSkinData = adapterReference.get().getPlayerSkinData(uuid.get());
-
-                if (playerSkinData.isPresent()) {
-                    return playerSkinData.map(data ->
-                            InputDataResult.of(SkinIdentifier.ofPlayer(uuid.get()), data.getProperty()));
+                        if (playerSkinData.isPresent()) {
+                            return playerSkinData.map(data ->
+                                    InputDataResult.of(SkinIdentifier.ofPlayer(uuid.get()), data.getProperty()));
+                        }
+                    }
                 }
             }
         } catch (StorageAdapter.StorageException | DataRequestException e) {
@@ -308,11 +313,17 @@ public class SkinStorageImpl implements SkinStorage {
     public Optional<InputDataResult> findOrCreateSkinData(String input, SkinVariant skinVariantHint) throws DataRequestException, MineSkinException {
         input = SRHelpers.sanitizeSkinInput(input);
 
+        // findSkinData handles prefix parsing internally for lookups
         Optional<InputDataResult> skinData = findSkinData(input, skinVariantHint);
 
         if (skinData.isPresent()) {
             return skinData;
         }
+
+        // Strip the prefix for the creation logic below
+        SkinInput skinInput = SkinInput.parse(input);
+        input = skinInput.name();
+        SkinType typeHint = skinInput.typeHint();
 
         // Create new skin data
         if (input.startsWith(RECOMMENDATION_PREFIX)) {
@@ -333,10 +344,12 @@ public class SkinStorageImpl implements SkinStorage {
             setURLSkinByResponse(input, response);
 
             return Optional.of(InputDataResult.of(SkinIdentifier.ofURL(input, response.getGeneratedVariant()), response.getProperty()));
-        } else {
+        } else if (typeHint != SkinType.CUSTOM) {
             return getPlayerSkin(input, false, true).map(result ->
                     InputDataResult.of(SkinIdentifier.ofPlayer(result.getUniqueId()), result.getSkinProperty()));
         }
+
+        return Optional.empty();
     }
 
     @Override


### PR DESCRIPTION
Custom skins are always checked before player skins in findSkinData(). If a custom skin has the same name as a real player (e.g. "Notch"), there was no way to force the player skin lookup.

Added SkinInput record that parses optional "player:" and "custom:" prefixes from the input string. When used, findSkinData() and findOrCreateSkinData() skip the irrelevant lookup branch:

- /skin set player:Notch  - always looks up the Mojang player skin
- /skin set custom:Notch  - always looks up the custom skin
- /skin set Notch  - unchanged behavior (custom first, then player)

<3